### PR TITLE
Enable copyArtifactPermission for every job

### DIFF
--- a/vars/pipelineDockerisedVega.groovy
+++ b/vars/pipelineDockerisedVega.groovy
@@ -254,7 +254,7 @@ void setupJobParameters(List inputParameters) {
 
     echo "params before=${params}"
 
-    properties([parameters(jobParameters)])
+    properties([copyArtifactPermission('*'), parameters(jobParameters)])
 
     echo "params=${params}"
 }


### PR DESCRIPTION
All PR pipelines are running the System Tests as a downstream job run in separate pipelines: `system-tests` and `system-tests-lnl`. As part of this process: the JUnit test result files must be copied back to the upstream pipelines as part of this process. By default, it is blocked by the job permissions.
Here, we enable this permission for the dockerised-vega pipeline, a base pipeline for both the `system-tests` and the `system-tests-lnl` pipelines.