### PR TITLE
Properly apply ignoreFailure for junit results

### DIFF
--- a/vars/systemTests.groovy
+++ b/vars/systemTests.groovy
@@ -71,7 +71,9 @@ void call(Map config = [:]) {
         )
 
         junit checksName: 'System Tests',
-            testResults: pipelineDefaults.art.systemTestsJunit
+              testResults: pipelineDefaults.art.systemTestsJunit,
+              skipMarkingBuildUnstable: ignoreFailure,
+              skipPublishingChecks: ignoreFailure
 
     } catch (e) {
         echo "Ignoring error in gathering results from downstream build: ${e}"

--- a/vars/systemTestsLNL.groovy
+++ b/vars/systemTestsLNL.groovy
@@ -76,6 +76,11 @@ void call(Map config = [:]) {
             filter: pipelineDefaults.art.lnl.systemTestsCreateState
         )
 
+        junit checksName: 'LNL System Tests Create',
+              testResults: pipelineDefaults.art.lnl.systemTestsCreateState,
+              skipMarkingBuildUnstable: ignoreFailure,
+              skipPublishingChecks: ignoreFailure
+
         copyArtifacts(
             projectName: systemTestsLNLJob,
             selector: specific("${st.number}"),
@@ -83,11 +88,10 @@ void call(Map config = [:]) {
             filter: pipelineDefaults.art.lnl.systemTestsAssertState
         )
 
-        junit checksName: 'LNL System Tests Create',
-            testResults: pipelineDefaults.art.lnl.systemTestsCreateState
-
         junit checksName: 'LNL System Tests Assert',
-            testResults: pipelineDefaults.art.lnl.systemTestsAssertState
+              testResults: pipelineDefaults.art.lnl.systemTestsAssertState,
+              skipMarkingBuildUnstable: ignoreFailure,
+              skipPublishingChecks: ignoreFailure
 
     } catch (e) {
         echo "Ignoring error in gathering results from downstream build: ${e}"


### PR DESCRIPTION
When `ignoreFailure` is set, then we need to disable two effects of the `junit` step:
- do not mark build as UNSTABLE,
- do not publish results as a GitHub check.