### PR TITLE
DV pipeline: by default use latest published versions

### DIFF
--- a/src/io/vegaprotocol/DockerisedVega.groovy
+++ b/src/io/vegaprotocol/DockerisedVega.groovy
@@ -46,10 +46,10 @@ void init(Map config=[:]) {
     marketProposalsFile = config.marketProposalsFile
     dlv = config.dlv ?: false
 
-    vegaCoreVersion = config.vegaCoreVersion ?: prefix
-    dataNodeVersion = config.dataNodeVersion ?: prefix
-    goWalletVersion = config.goWalletVersion ?: prefix
-    ethereumEventForwarderVersion = config.ethereumEventForwarder ?: prefix
+    vegaCoreVersion = config.vegaCoreVersion
+    dataNodeVersion = config.dataNodeVersion
+    goWalletVersion = config.goWalletVersion
+    ethereumEventForwarderVersion = config.ethereumEventForwarder
 
     dockerImageVegaCore = "docker.pkg.github.com/vegaprotocol/vega/vega:${vegaCoreVersion}"
     dockerImageDataNode = "docker.pkg.github.com/vegaprotocol/data-node/data-node:${dataNodeVersion}"
@@ -81,6 +81,18 @@ String toString() {
 
 void run(String command, boolean resume = false) {
     String extraArguments = ''
+    if (vegaCoreVersion) {
+        extraArguments += " --vega-version \"${vegaCoreVersion}\""
+    }
+    if (dataNodeVersion) {
+        extraArguments += " --datanode-version \"${dataNodeVersion}\""
+    }
+    if (goWalletVersion) {
+        extraArguments += " --vegawallet-version \"${goWalletVersion}\""
+    }
+    if (ethereumEventForwarderVersion) {
+        extraArguments += " --eef-version \"${ethereumEventForwarderVersion}\""
+    }
     if (genesisFile) {
         extraArguments += " --genesis \"${genesisFile}\""
 
@@ -101,10 +113,6 @@ void run(String command, boolean resume = false) {
             --portbase "${portbase}" \
             --validators "${validators}" \
             --nonvalidators "${nonValidators}" \
-            --vega-version "${vegaCoreVersion}" \
-            --datanode-version "${dataNodeVersion}" \
-            --vegawallet-version "${goWalletVersion}" \
-            --eef-version "${ethereumEventForwarderVersion}" \
             --tendermint-loglevel "${tendermintLogLevel}" \
             --vega-loglevel "${vegaCoreLogLevel}" \
             ${extraArguments} \

--- a/vars/pipelineDefaults.groovy
+++ b/vars/pipelineDefaults.groovy
@@ -8,10 +8,10 @@ import groovy.transform.Field
 // Dockerised Vega pipeline
 @Field
 Map dv = [
-    vegaCoreBranch: 'develop',
-    dataNodeBranch: 'develop',
-    goWalletBranch: 'develop',
-    ethereumEventForwarderBranch: 'main',
+    vegaCoreBranch: '', // 'develop',
+    dataNodeBranch: '', // 'develop',
+    goWalletBranch: '', // 'develop',
+    ethereumEventForwarderBranch: '', // 'main',
     devopsInfraBranch: 'master',
     vegatoolsBranch: 'develop',
 


### PR DESCRIPTION
Add option to skip clone and build of vega core, data-node, go-wallet and eef. Instead, use the latest published version