### PR TITLE
Create new pipeline to startup Private Network

### DIFF
--- a/src/io/vegaprotocol/DockerisedVega.groovy
+++ b/src/io/vegaprotocol/DockerisedVega.groovy
@@ -1,4 +1,5 @@
 /* groovylint-disable DuplicateStringLiteral */
+/* groovylint-disable DuplicateNumberLiteral */
 /* groovylint-disable CompileStatic */
 package io.vegaprotocol
 
@@ -95,7 +96,7 @@ void run(String command, boolean resume = false) {
         extraArguments += ' --resume'
     }
     sh label: 'start dockerised-vega', script: """#!/bin/bash -e
-        ${dockerisedvagaScript} \
+        "${dockerisedvagaScript}" \
             --datadir "${basedir}" \
             --prefix "${prefix}" \
             --portbase "${portbase}" \
@@ -128,7 +129,7 @@ void stop(Map config) {
         extraArguments += ' --resume'
     }
     sh label: 'stop dockerised-vega', script: """#!/bin/bash -e
-        ${dockerisedvagaScript} \
+        "${dockerisedvagaScript}" \
             --prefix '${prefix}' \
             --portbase '${portbase}' \
             ${extraArguments} \
@@ -138,7 +139,7 @@ void stop(Map config) {
 
 void pull() {
     sh label: 'docker pull for dockerised-vega', script: """#!/bin/bash -e
-        ${dockerisedvagaScript} pull
+        "${dockerisedvagaScript}" pull
     """
 }
 
@@ -208,7 +209,7 @@ void saveLatestCheckpointToFile(String targetFile, int node=0) {
     String checkpointFile = getLatestCheckpointFilepath(node)
     sh label: 'Convert checkpoint to json format', script: """
         mkdir -p "\$(dirname ${targetFile})"
-        ${vegatoolsScript} checkpoint -v \
+        "${vegatoolsScript}" checkpoint -v \
             -f "${checkpointFile}" \
             -o "${targetFile}"
     """
@@ -220,4 +221,52 @@ void saveGenesisToFile(String targetFile, int node=0) {
         mkdir -p "\$(dirname ${targetFile})"
         cp "${genesisFile}" "${targetFile}"
     """
+}
+
+Map<String,Map<String,String>> getEndpointInformation(String ip) {
+    Map<String,Map<String,String>> result = [:]
+
+    for (int node = 0; node < validators; node++) {
+        result["validator node ${node}"] = [
+            'gRPC': "${ip}:${portbase + 10 * node + 2}",
+            'gql': "http://${ip}:${portbase + 10 * node + 3}",
+            'REST': "http://${ip}:${portbase + 10 * node + 4}"
+        ]
+    }
+    for (int node = validators; node < validators + nonValidators; node++) {
+        result["non-validator node ${node}"] = [
+            'gRPC': "${ip}:${portbase + 10 * node + 2}",
+            'gql': "http://${ip}:${portbase + 10 * node + 3}",
+            'REST': "http://${ip}:${portbase + 10 * node + 4}"
+        ]
+    }
+    for (int node = validators; node < validators + nonValidators; node++) {
+        result["data-node ${node}"] = [
+            'gRPC': "${ip}:${portbase + 100 + 10 * node + 7}",
+            'gql': "http://${ip}:${portbase + 100 + 10 * node + 8}",
+            'REST': "http://${ip}:${portbase + 100 + 10 * node + 9}"
+        ]
+    }
+    result['Ganache'] = [
+        'REST': "http://${ip}:${portbase + 545}"
+    ]
+    result['Smart contracts'] = [
+        'docs': "http://${ip}:${portbase + 80}"
+    ]
+    result['Vega faucet'] = [
+        'gRPC': "${ip}:${portbase + 790}"
+    ]
+    result['Vega wallet'] = [
+        'gRPC': "${ip}:${portbase + 789}"
+    ]
+
+    return result
+}
+
+Map<String,String> getUsefulLinks(String ip) {
+    Map<String,String> result = [:]
+
+    result['Network statistics'] = "http://${ip}:${portbase + 100 + 10 * validators + 9}/statistics"
+
+    return result
 }

--- a/vars/pipelineDockerisedVega.groovy
+++ b/vars/pipelineDockerisedVega.groovy
@@ -560,7 +560,7 @@ Map<String,Closure> getPrepareDockerisedVegaStages(
     return ['dv': {
         stage('Setup') {
             sh label: 'Create dockerised vega basedir',
-                script: "mkdir -p ${dockerisedVega.basedir}"
+                script: "mkdir -p '${dockerisedVega.basedir}'"
         }
         stage('Create config files') {
             if (dockerisedVega.genesisFile?.trim()) {
@@ -608,10 +608,8 @@ Map<String,Closure> getPrepareDockerisedVegaStages(
         }
         stage('Docker Pull') {
             retry(3) {
-                dir('devops-infra/scripts') {
-                    withDockerRegistry(dockerCredentials) {
-                        dockerisedVega.pull()
-                    }
+                withDockerRegistry(dockerCredentials) {
+                    dockerisedVega.pull()
                 }
             }
         }

--- a/vars/pipelinePrivateNetwork.groovy
+++ b/vars/pipelinePrivateNetwork.groovy
@@ -1,0 +1,67 @@
+/* groovylint-disable DuplicateStringLiteral */
+/* groovylint-disable DuplicateNumberLiteral */
+/* groovylint-disable MethodSize */
+/* groovylint-disable UnnecessaryGetter */
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
+import io.vegaprotocol.DockerisedVega
+
+void call() {
+    echo "buildCauses=${currentBuild.buildCauses}"
+    if (currentBuild.upstreamBuilds) {
+        RunWrapper upBuild = currentBuild.upstreamBuilds[0]
+        currentBuild.displayName = "#${currentBuild.id} - ${upBuild.fullProjectName} #${upBuild.id}"
+    }
+    pipelineDockerisedVega.call([
+        parameters: [
+            string(
+                name: 'NAME', defaultValue: '',
+                description: 'Network name - used only to display on Jenkins'),
+            string(
+                name: 'TIMEOUT', defaultValue: '200',
+                description: 'Timeout after which the network will be stopped. Default 200min'),
+            string(
+                name: 'JENKINS_AGENT_LABEL', defaultValue: 'private-network',
+                description: 'Specify Jenkins machine on which to run this pipeline')
+        ],
+        prepareStages: [
+            'net': { Map vars ->
+                stage('Set name') {
+                    String whoStarted = currentBuild.getBuildCauses()[0].shortDescription - 'Started by user '
+                    String networkName = params.NAME ?: whoStarted
+                    currentBuild.displayName = "${networkName} #${currentBuild.id}"
+                }
+            }
+        ],
+
+        mainStage: { Map vars ->
+            DockerisedVega dockerisedVega = vars.dockerisedVega
+            String ip = vars.jenkinsAgentPublicIP
+            Map<String,String> usefulLinks = dockerisedVega.getUsefulLinks(ip)
+            Map<String,Map<String,String>> endpointInfo = dockerisedVega.getEndpointInformation(ip)
+            List parameters = []
+
+            usefulLinks.eachWithIndex { linkName, linkURL, index ->
+                if (index == 0) {
+                    parameters << booleanParam(description: 'Useful links', name: "[${linkName}]: ${linkURL}")
+                } else {
+                    parameters << booleanParam(name: "[${linkName}]: ${linkURL}")
+                }
+            }
+
+            endpointInfo.each { machine, endpoints ->
+                endpoints.eachWithIndex { endpointType, endpoint, index ->
+                    if (index == 0) {
+                        parameters << booleanParam(description: machine, name: "[${endpointType}]: ${endpoint}")
+                    } else {
+                        parameters << booleanParam(name: "[${endpointType}]: ${endpoint}")
+                    }
+                }
+            }
+
+            timeout(time: params.TIMEOUT as int, unit: 'MINUTES') {
+                input message: 'Private network is ready', ok: 'Stop network',
+                    parameters: parameters
+            }
+        }
+    ])
+}

--- a/vars/systemTests.groovy
+++ b/vars/systemTests.groovy
@@ -60,7 +60,7 @@ void call(Map config = [:]) {
         echo "System-Tests execution pipeline: ${st.absoluteUrl}"
 
         sh label: 'remove old junit result file', script: """#!/bin/bash -e
-            rm -f ${pipelineDefaults.art.systemTestsJunit}
+            rm -f "${pipelineDefaults.art.systemTestsJunit}"
         """
 
         copyArtifacts(

--- a/vars/systemTestsLNL.groovy
+++ b/vars/systemTestsLNL.groovy
@@ -65,8 +65,8 @@ void call(Map config = [:]) {
         echo "LNL System-Tests execution pipeline: ${st.absoluteUrl}"
 
         sh label: 'remove old junit result file', script: """#!/bin/bash -e
-            rm -f ${pipelineDefaults.art.lnl.systemTestsCreateState}
-            rm -f ${pipelineDefaults.art.lnl.systemTestsAssertState}
+            rm -f "${pipelineDefaults.art.lnl.systemTestsCreateState}"
+            rm -f "${pipelineDefaults.art.lnl.systemTestsAssertState}"
         """
 
         copyArtifacts(


### PR DESCRIPTION
Add a pipeline where:
- you can startup a Vega Network with a single click,
- start on a separate Jenkins machine with ports open. Wait for User interaction to stop the Network,
- allow specifying the version of vega core, data-node, eef, go-wallet etc. By default use latest published,
- allow further customization with genesis, node numbers, etc.