### PR TITLE
Pass the location of the vegatools script to the system tests.

### DIFF
--- a/vars/pipelineSystemTests.groovy
+++ b/vars/pipelineSystemTests.groovy
@@ -81,6 +81,7 @@ void call() {
                 "SYSTEM_TESTS_PORTBASE=${dockerisedVega.portbase}",
                 "SYSTEM_TESTS_DEBUG=${params.SYSTEM_TESTS_DEBUG}",
                 "SYSTEM_TESTS_LNL_STATE=${env.WORKSPACE}/${pipelineDefaults.art.systemTestsState}",
+                "VEGATOOLS=${dockerisedVega.vegatoolsScript}",
             ]) {
                 stage('Check setup') {
                     sh 'printenv'


### PR DESCRIPTION
Enables https://github.com/vegaprotocol/system-tests/pull/272. Change on its own should be harmless.