### PR TITLE
Specify full path to system test jobs to avoid naming conflicts when …

### DIFF
--- a/vars/systemTests.groovy
+++ b/vars/systemTests.groovy
@@ -1,7 +1,7 @@
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 
 void call(Map config = [:]) {
-    String systemTestsJob = 'system-tests/system-tests'
+    String systemTestsJob = '/system-tests/system-tests'
     Boolean ignoreFailure = config.ignoreFailure ? "${config.ignoreFailure}".toBoolean() : false
     List buildParameters = [
             // Different repos branches

--- a/vars/systemTestsLNL.groovy
+++ b/vars/systemTestsLNL.groovy
@@ -3,7 +3,7 @@
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 
 void call(Map config = [:]) {
-    String systemTestsLNLJob = 'system-tests/LNL-create-restore'
+    String systemTestsLNLJob = '/system-tests/LNL-create-restore'
     Boolean ignoreFailure = config.ignoreFailure ? "${config.ignoreFailure}".toBoolean() : false
     List buildParameters = [
             // Different repos branches


### PR DESCRIPTION
…adding jobs inside the system tests directory.

This job:
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/system-tests%2FNightly%20Full%20System%20Test%20Run/detail/Nightly%20Full%20System%20Test%20Run/1/pipeline/
Seems to prove that absolute paths to Jenkins jobs are a thing, and work. I think that makes this PR safe to merge.

Without this PR, the subjobs were failing with errors like:
`No item named system-tests/system-tests found`
...since they were being launched by a pipeline in a directory with a job that conflicted with the directory name we were looking for. Afterwards, the absolute path reaches the jobs. This should continue to work for other pipelines.