### PR TITLE
Disable checking known hosts for ansible

### DIFF
--- a/vars/pipelineStagnetDeploy.groovy
+++ b/vars/pipelineStagnetDeploy.groovy
@@ -89,7 +89,7 @@ void call() {
                                     withCredentials([sshStagnetCredentials]) {
                                         sh label: 'ansible dry run', script: """#!/bin/bash -e
                                             export ANSIBLE_FORCE_COLOR=true
-                                            ansible-playbook \
+                                            ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
                                                 --check --diff \
                                                 -u "\${PSSH_USER}" \
                                                 --private-key "\${PSSH_KEYFILE}" \
@@ -141,7 +141,7 @@ void call() {
                                     //        are set by withCredentials wrapper
                                     sh label: 'ansible deploy run', script: """#!/bin/bash -e
                                         export ANSIBLE_FORCE_COLOR=true
-                                        ansible-playbook \
+                                        ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
                                             -u "\${PSSH_USER}" \
                                             --private-key "\${PSSH_KEYFILE}" \
                                             -i hosts \


### PR DESCRIPTION
We do not have known_hosts when new jenkins runner is starting