### PR TITLE
fix: Make mainnet pipeline trigger the legacy checkpoint behaviour

### DIFF
--- a/src/io/vegaprotocol/DockerisedVega.groovy
+++ b/src/io/vegaprotocol/DockerisedVega.groovy
@@ -84,7 +84,7 @@ String toString() {
         "tendermintLogLevel=\"${tendermintLogLevel}\", vegaCoreLogLevel=\"${vegaCoreLogLevel}\")"
 }
 
-void run(String command, boolean resume = false) {
+void run(String command, boolean resume = false, boolean legacy = false) {
     String extraArguments = ''
     if (vegaCoreVersion) {
         extraArguments += " --vega-version \"${vegaCoreVersion}\""
@@ -113,6 +113,9 @@ void run(String command, boolean resume = false) {
     if (resume) {
         extraArguments += ' --resume'
     }
+    if (legacy) {
+        extraArguments += ' --legacy-resume'
+    }
     sh label: 'start dockerised-vega', script: """#!/bin/bash -e
         "${dockerisedvagaScript}" \
             --datadir "${basedir}" \
@@ -129,12 +132,14 @@ void run(String command, boolean resume = false) {
 
 void start(Map config) {
     boolean resume = config?.resume ?: false
-    run('start', resume)
+    boolean legacy = config?.legacy ?: false
+    run('start', resume, legacy)
 }
 
 void restart(Map config) {
     boolean resume = config?.resume ?: false
-    run('restart', resume)
+    boolean legacy = config?.legacy ?: false
+    run('restart', resume, legacy)
 }
 
 void stop(Map config) {

--- a/src/io/vegaprotocol/DockerisedVega.groovy
+++ b/src/io/vegaprotocol/DockerisedVega.groovy
@@ -50,7 +50,7 @@ void init(Map config=[:]) {
     mainnet = config.mainnet ?: false
     genesisFile = config.genesisFile
     checkpointFile = config.checkpointFile
-    legacyResume = config.legacyResume
+    legacyResume = config.legacyResume ?: false
     ethEndpointUrl = config.ethEndpointUrl
 
     dlv = config.dlv ?: false
@@ -86,7 +86,7 @@ String toString() {
         "tendermintLogLevel=\"${tendermintLogLevel}\", vegaCoreLogLevel=\"${vegaCoreLogLevel}\")"
 }
 
-void run(String command, boolean resume = false, boolean legacy = false) {
+void run(String command, boolean resume = false) {
     String extraArguments = ''
     if (vegaCoreVersion) {
         extraArguments += " --vega-version \"${vegaCoreVersion}\""

--- a/src/io/vegaprotocol/DockerisedVega.groovy
+++ b/src/io/vegaprotocol/DockerisedVega.groovy
@@ -17,6 +17,7 @@ dlv
 mainnet
 genesisFile
 checkpointFile
+legacyResume
 ethEndpointUrl
 
 vegaCoreVersion
@@ -49,6 +50,7 @@ void init(Map config=[:]) {
     mainnet = config.mainnet ?: false
     genesisFile = config.genesisFile
     checkpointFile = config.checkpointFile
+    legacyResume = config.legacyResume
     ethEndpointUrl = config.ethEndpointUrl
 
     dlv = config.dlv ?: false
@@ -113,7 +115,7 @@ void run(String command, boolean resume = false, boolean legacy = false) {
     if (resume) {
         extraArguments += ' --resume'
     }
-    if (legacy) {
+    if (legacyResume) {
         extraArguments += ' --legacy-resume'
     }
     sh label: 'start dockerised-vega', script: """#!/bin/bash -e
@@ -132,14 +134,12 @@ void run(String command, boolean resume = false, boolean legacy = false) {
 
 void start(Map config) {
     boolean resume = config?.resume ?: false
-    boolean legacy = config?.legacy ?: false
-    run('start', resume, legacy)
+    run('start', resume)
 }
 
 void restart(Map config) {
     boolean resume = config?.resume ?: false
-    boolean legacy = config?.legacy ?: false
-    run('restart', resume, legacy)
+    run('restart', resume)
 }
 
 void stop(Map config) {

--- a/src/io/vegaprotocol/DockerisedVega.groovy
+++ b/src/io/vegaprotocol/DockerisedVega.groovy
@@ -115,7 +115,7 @@ void run(String command, boolean resume = false) {
     if (resume) {
         extraArguments += ' --resume'
     }
-    if (legacyResume) {
+    if (legacyResume && checkpointFile) {
         extraArguments += ' --legacy-resume'
     }
     sh label: 'start dockerised-vega', script: """#!/bin/bash -e

--- a/vars/pipelineDefaults.groovy
+++ b/vars/pipelineDefaults.groovy
@@ -26,6 +26,7 @@ Map dv = [
     genesisJSON: '',
     mainnetGenesis: 'system-tests/tests/LNL/mainnet/genesis.json',
     checkpoint: '',
+    legacyResume: false,
     ethEndpointUrl: '',
 
     tendermintLogLevel: 'info',
@@ -62,6 +63,7 @@ Map mnnt = st + [
     testFunction: 'test_checkpoint_loaded',
     testMark: '',
     afterLoadCheckpoint: "system-tests/tests/LNL/after_checkpoint_load.json",
+    legacyResume: true,
 ]
 
 @Field

--- a/vars/pipelineDefaults.groovy
+++ b/vars/pipelineDefaults.groovy
@@ -56,6 +56,12 @@ Map lnl = st + [
     testFunctionAssert: 'assert_data_test'
 ]
 
+// Private Network pipeline
+@Field
+Map pn = dv + [
+    legacyResume: true,
+]
+
 // Mainnet checkpoint test pipeline
 @Field
 Map mnnt = st + [

--- a/vars/pipelineDockerisedVega.groovy
+++ b/vars/pipelineDockerisedVega.groovy
@@ -54,6 +54,7 @@ void call(Map config=[:]) {
             mainnet: params.DV_MAINNET,
             genesisFile: genesisJSON,
             checkpointFile: params.DV_CHECKPOINT,
+            legacyResume: params.DV_LEGACY_RESUME,
             ethEndpointUrl: params.DV_ETH_ENDPOINT,
             dlv: params.DV_VEGA_CORE_DLV,
             vegaCoreVersion: params.VEGA_CORE_BRANCH ? dockerisedVegaPrefix : null,
@@ -172,7 +173,7 @@ void call(Map config=[:]) {
                             retry(2) {
                                 timeout(time: 10, unit: 'MINUTES') {
                                     withDockerRegistry(vars.dockerCredentials) {
-                                        dockerisedVega.start(resume: true, legacy: params.DV_LEGACY_RESUME)
+                                        dockerisedVega.start(resume: true)
                                     }
                                 }
                             }
@@ -760,6 +761,13 @@ Map<String,Closure> getPrepareDockerisedVegaStages(
                 echo 'Skip setting default Eth url: no mainnet setup or Ethereum url is provided.'
                 Utils.markStageSkippedForConditional(setEthURLStageName)
             }
+        }
+        String setLegacyResumeStatus = 'Set legacy resume status'
+        stage(setLegacyResumeStatus) {
+            dockerisedVega.legacyResume = params.DV_LEGACY_RESUME
+            sh label: 'Set legacyResume flag.', script: """#!/bin/bash -e
+                    echo 'Set legacyResume to ${params.DV_LEGACY_RESUME}'
+                """
         }
     }]
 }

--- a/vars/pipelineDockerisedVega.groovy
+++ b/vars/pipelineDockerisedVega.groovy
@@ -172,7 +172,7 @@ void call(Map config=[:]) {
                             retry(2) {
                                 timeout(time: 10, unit: 'MINUTES') {
                                     withDockerRegistry(vars.dockerCredentials) {
-                                        dockerisedVega.start(resume: true)
+                                        dockerisedVega.start(resume: true, legacy: params.DV_LEGACY_RESUME)
                                     }
                                 }
                             }
@@ -320,6 +320,9 @@ void setupJobParameters(List inputParameters, List inputProperties) {
             description: '''Checkpoint to restore network from. A path to a cp file.
             For mainnet option leave this field empty and the latest Mainnet checkpoint will be downloaded.
             '''),
+        booleanParam(
+            name: 'DV_LEGACY_RESUME', defaultValue: pipelineDefaults.dv.legacyResume,
+            description: 'Use the legacy flag for resuming from checkpoint.'),
         string(
             name: 'DV_ETH_ENDPOINT', defaultValue: pipelineDefaults.dv.ethEndpointUrl,
             description: 'Ethereum endpoint url, e.g. Infura. Leave empty to use Jenkins instance.'),

--- a/vars/pipelineMainnetCheckpointTests.groovy
+++ b/vars/pipelineMainnetCheckpointTests.groovy
@@ -40,6 +40,9 @@ void call() {
             booleanParam(
                 name: 'SYSTEM_TESTS_DEBUG', defaultValue: pipelineDefaults.mnnt.systemTestsDebug,
                 description: 'Enable debug logs for system-tests execution'),
+            booleanParam(
+                name: 'DV_LEGACY_RESUME', defaultValue: pipelineDefaults.mnnt.legacyResume,
+                description: 'Use the legacy flag for resuming from checkpoint.'),
         ],
         properties: [
             durabilityHint('PERFORMANCE_OPTIMIZED'),

--- a/vars/pipelinePrivateNetwork.groovy
+++ b/vars/pipelinePrivateNetwork.groovy
@@ -22,6 +22,9 @@ void call() {
             string(
                 name: 'JENKINS_AGENT_LABEL', defaultValue: 'private-network',
                 description: 'Specify Jenkins machine on which to run this pipeline'),
+            booleanParam(
+                name: 'DV_LEGACY_RESUME', defaultValue: pipelineDefaults.pn.legacyResume,
+                description: 'Use the legacy flag for resuming from checkpoint. (Only used with mainnet flag).'),
         ],
         properties: [
             durabilityHint('PERFORMANCE_OPTIMIZED'),


### PR DESCRIPTION
This should have the effect of:
- Regular LNL tests resume the network after checkpoints as they do currently (the new behaviour)
- Mainnet pipeline should pass the "--legacy-resume" flag to DV, which ought to trigger the old behaviour.
- We can flip/remove later, once mainnet is on a more recent version.