### PR TITLE
Add git clone helper

### DIFF
--- a/vars/gitClone.groovy
+++ b/vars/gitClone.groovy
@@ -1,0 +1,60 @@
+/* groovylint-disable DuplicateStringLiteral */
+/* groovylint-disable DuplicateNumberLiteral */
+
+void doClone(Map config) {
+  checkout([
+    $class: 'GitSCM',
+    branches: [[name: config?.branch]],
+    userRemoteConfigs: [[
+      url: config?.url,
+      credentialsId: config?.credentialsId
+  ]]])
+}
+
+void call(Map additionalConfig) {
+  Map defaultCconfig = [
+      directory: '',
+      branch: 'main',
+      url: '',
+      credentialsId: ''
+  ]
+
+  Map config = defaultCconfig + additionalConfig
+
+  ['branch', 'url', 'credentialsId'].each { item ->
+    if (config[item]?.length() < 1) {
+      error('[gitClone] Field config.' + item + ' cannot be empty')
+    }
+  }
+
+  if (config.directory == '') {
+    return doClone(config)
+  }
+
+  dir(config.directory) {
+    doClone(config)
+  }
+}
+
+/**
+ * Example usage
+ */
+// gitClone([
+//   credentialsId: 'vega-ci-bot',
+//   url: 'git@github.com:vegaprotocol/vegacapsule.git',
+//   branch: 'main'
+// ])
+
+// gitClone([
+//   credentialsId: 'vega-ci-bot',
+//   url: 'git@github.com:vegaprotocol/vegacapsule.git',
+//   branch: 'main',
+//   directory: 'abc'
+// ])
+
+// gitClone([
+//   credentialsId: 'vega-ci-bot',
+//   url: 'git@github.com:vegaprotocol/vegacapsule.git',
+//   branch: 'main',
+//   directory: 'def'
+// ])


### PR DESCRIPTION
Part of #95 

Tested here: https://jenkins.ops.vega.xyz/job/Experiments/job/gitClone/11/console

With the following code:

```
@Library('vega-shared-library@git-clone') _


node('system-tests-capsule') {
  stage('test') {
    gitClone([
      credentialsId: 'vega-ci-bot',
      url: 'git@github.com:vegaprotocol/vegacapsule.git',
      branch: 'main'
    ])

    gitClone([
      credentialsId: 'vega-ci-bot',
      url: 'git@github.com:vegaprotocol/vegacapsule.git',
      branch: 'main',
      directory: 'abc'
    ])

    gitClone([
      credentialsId: 'vega-ci-bot',
      branch: 'main',
      directory: 'def'
    ])

    sh 'pwd'
    sh 'ls -als'

    dir('abc') {
      sh 'pwd'
      sh 'ls -als'
    }

    dir('def') {
      sh 'pwd'
      sh 'ls -als'
    }
  }
}

```