### PR TITLE
Update default configuration for approbation pipe

### DIFF
--- a/vars/pipelineDefaults.groovy
+++ b/vars/pipelineDefaults.groovy
@@ -105,9 +105,9 @@ Map appr = [
     systemTestsBranch: 'develop',
     specsArg: '{./specs-internal/protocol/**/*.{md,ipynb},./specs-internal/non-protocol-specs/**/*.{md,ipynb}}',
     testsArg: '{./system-tests/tests/**/*.py,./vega/integration/**/*.{go,feature},./MultisigControl/test/*.js}',
-    ignoreArg: './specs-internal/non-protocol-specs/{0001-NP*,0002-NP*,0004-NP*,0006-NP*,0007-NP*,0008-NP*,0010-NP*}',
-    otherArg: '--show-branches',
-    approbationVersion: '2.3.4'
+    ignoreArg: '{./spec-internal/protocol/0060*,./specs-internal/non-protocol-specs/{0001-NP*,0002-NP*,0004-NP*,0006-NP*,0007-NP*,0008-NP*,0010-NP*}}',
+    otherArg: '--show-branches --show-mystery --category-stats --show-files --verboses',
+    approbationVersion: '2.4.1'
 ]
 
 @Field


### PR DESCRIPTION
- Update to `v2.4.1`
- Update `ignore` param to ignore Wendy spec
- Update extra params to show verbose output