### PR TITLE
Update approbation default config & minor pipeline changes

### DIFF
--- a/vars/pipelineDefaults.groovy
+++ b/vars/pipelineDefaults.groovy
@@ -133,7 +133,7 @@ Map appr = [
     testsArg: '{./system-tests/tests/**/*.py,./vega/integration/**/*.{go,feature},./MultisigControl/test/*.js}',
     ignoreArg: '{./spec-internal/protocol/0060*,./specs-internal/non-protocol-specs/{0001-NP*,0002-NP*,0004-NP*,0006-NP*,0007-NP*,0008-NP*,0010-NP*}}',
     otherArg: '--show-branches --show-mystery --category-stats --show-files --verbose --output-csv --output-jenkins',
-    approbationVersion: '2.4.2'
+    approbationVersion: '2.4.3'
 ]
 
 @Field

--- a/vars/pipelineDefaults.groovy
+++ b/vars/pipelineDefaults.groovy
@@ -132,8 +132,8 @@ Map appr = [
     specsArg: '{./specs-internal/protocol/**/*.{md,ipynb},./specs-internal/non-protocol-specs/**/*.{md,ipynb}}',
     testsArg: '{./system-tests/tests/**/*.py,./vega/integration/**/*.{go,feature},./MultisigControl/test/*.js}',
     ignoreArg: '{./spec-internal/protocol/0060*,./specs-internal/non-protocol-specs/{0001-NP*,0002-NP*,0004-NP*,0006-NP*,0007-NP*,0008-NP*,0010-NP*}}',
-    otherArg: '--show-branches --show-mystery --category-stats --show-files --verboses',
-    approbationVersion: '2.4.1'
+    otherArg: '--show-branches --show-mystery --category-stats --show-files --verbose --output-csv --output-jenkins',
+    approbationVersion: '2.4.2'
 ]
 
 @Field


### PR DESCRIPTION
Done so far:
- Bump version
- Fix incorrect `--verbose` argument
- Add `output-jenkins`
- add `output-csv`

Please could someone from Ops complete these last two tasks:

- [x] Store `results/output.csv` as an artefact
- [x] `cat results/jenkins.txt` in to the Slack message