### PR TITLE
ci: Increase the default timeout for the Vega Capsule System Test job…

### DIFF
--- a/vars/pipelineDefaults.groovy
+++ b/vars/pipelineDefaults.groovy
@@ -63,7 +63,7 @@ Map capsuleSystemTests = [
     systemTestsTestMark: 'smoke',
     systemTestsTestDirectory: '',
     systemTestsDebug: false,
-    systemTestsRunTimeout: '60',
+    systemTestsRunTimeout: '300',
     printNetworkLogsInJenkinsPipeline: false,
 ]
 


### PR DESCRIPTION
… to be long enough to allow the 'full' run.

People keep forgetting to allow more time when running the full run, which costs about an 1.5 hours of the doomed run, notice, ask for help, and finally re-run with correct params. All of the pipelines specify a timeout on the parent jobs anyway, so we'll still kill smoke runs early if they hang for PRs/develop etc... for various repos. I can't see any harm in doing this?