### PR TITLE
fix: Print logs when network is failed before docker containers are removed

### DIFF
--- a/vars/pipelineDockerisedVega.groovy
+++ b/vars/pipelineDockerisedVega.groovy
@@ -222,11 +222,14 @@ void call(Map config=[:]) {
                         } else {
                             echo 'Skip waiting for next checkpoint - no node is running'
                         }
-                        retry(3) {
-                            dockerisedVega.stop()
-                        }
+
+
                         if (currentBuild.result != 'SUCCESS' ) {
                             dockerisedVega.printAllLogs()
+                        }
+
+                        retry(3) {
+                            dockerisedVega.stop()
                         }
                         String artifactLastCheckpoint = pipelineDefaults.art.checkpointEnd
                         if (inputAfterCheckpointRestoreStage) {


### PR DESCRIPTION
Tested here: https://jenkins.ops.vega.xyz/job/private/job/LNL-create-restore/7035/

`dockerisedvega.stop()` without the `resume` removes containers, so we have to print logs before it.

```

[2022-06-07T17:49:00.872Z] Stopping and removing container(s): dv-LNL-create-restore-7035-1-vega-faucet*
[2022-06-07T17:49:01.134Z] 1dfc776b380b
[2022-06-07T17:49:01.440Z] 1dfc776b380b
[2022-06-07T17:49:01.440Z] Stopping and removing container(s): dv-LNL-create-restore-7035-1-vega-wallet*
[2022-06-07T17:49:01.740Z] 59ebfd8d87cb
[2022-06-07T17:49:02.046Z] 59ebfd8d87cb
[2022-06-07T17:49:02.046Z] Stopping and removing container(s): dv-LNL-create-restore-7035-1-data-node*
[2022-06-07T17:49:02.713Z] 019a307ffb43
[2022-06-07T17:49:02.977Z] 019a307ffb43
[2022-06-07T17:49:02.977Z] Stopping and removing container(s): dv-LNL-create-restore-7035-1-vega-node*
[2022-06-07T17:49:03.629Z] 9c8e9db07358
[2022-06-07T17:49:05.146Z] 02888d752db0
[2022-06-07T17:49:06.622Z] 454d35f1e6f2
[2022-06-07T17:49:06.886Z] 9c8e9db07358
[2022-06-07T17:49:06.886Z] 02888d752db0
[2022-06-07T17:49:06.886Z] 454d35f1e6f2
[2022-06-07T17:49:06.886Z] Stopping and removing container(s): dv-LNL-create-restore-7035-1-tendermint-node*
[2022-06-07T17:49:07.158Z] 3eef4f6af376
[2022-06-07T17:49:07.158Z] 0cf902b43d39
[2022-06-07T17:49:07.158Z] df15a85e1938
[2022-06-07T17:49:07.158Z] Stopping and removing container(s): dv-LNL-create-restore-7035-1-tendermint-init*
[2022-06-07T17:49:07.158Z] Stopping and removing container(s): dv-LNL-create-restore-7035-1-vega-smartcontracts*
[2022-06-07T17:49:07.158Z] Stopping and removing container(s): dv-LNL-create-restore-7035-1-ganache*
[2022-06-07T17:49:07.729Z] fa438d08202b
[2022-06-07T17:49:07.995Z] fa438d08202b
[2022-06-07T17:49:07.995Z] Stopping and removing network: dv-LNL-create-restore-7035-1-veganet
[2022-06-07T17:49:08.302Z] 0020246eaeec
```