### PR TITLE
feat: make the vega capsule config a build parameter

### DIFF
--- a/vars/capsuleSystemTests.groovy
+++ b/vars/capsuleSystemTests.groovy
@@ -26,6 +26,8 @@ void call(Map additionalConfig) {
     systemTestsTestDirectory: '',
     systemTestsDebug: '',
 
+    capsuleConfig: 'capsule_config.hcl',
+
     preapareSteps: {},
     gitCredentialsId: 'vega-ci-bot',
     ignoreFailure: false,
@@ -95,7 +97,7 @@ void call(Map additionalConfig) {
     prepareSteps['prepare multisig setup script'] = {
       stage('prepare network config') {
         dir('system-tests') {
-          sh 'cp ./vegacapsule/capsule_config.hcl ' + testDirectoryPath + '/config_system_tests.hcl'
+          sh 'cp ./vegacapsule/' + config.capsuleConfig + ' ' + testDirectoryPath + '/config_system_tests.hcl'
         }
       }
     }

--- a/vars/capsuleSystemTests.groovy
+++ b/vars/capsuleSystemTests.groovy
@@ -87,8 +87,11 @@ void call(Map additionalConfig) {
   }
   
   stage('start nomad') {
+    dir('system-tests'){
+        sh 'cp ./vegacapsule/nomad_config.hcl' + ' ' + testDirectoryPath + '/nomad_config.hcl'
+    }
     dir ('tests') {
-        sh 'daemonize -o ' + testDirectoryPath + '/nomad.log -c ' + testDirectoryPath + ' -p ' + testDirectoryPath + '/vegacapsule_nomad.pid ' + testDirectoryPath + '/vegacapsule nomad'
+        sh 'daemonize -o ' + testDirectoryPath + '/nomad.log -c ' + testDirectoryPath + ' -p ' + testDirectoryPath + '/vegacapsule_nomad.pid ' + testDirectoryPath + '/vegacapsule nomad --nomad-config-path=' + testDirectoryPath + '/nomad_config.hcl'
     }
   }
 

--- a/vars/pipelineCapsuleSystemTests.groovy
+++ b/vars/pipelineCapsuleSystemTests.groovy
@@ -38,6 +38,8 @@ void call() {
           command-line argument, see more: https://docs.pytest.org/en/stable/usage.html'''),
       string(name: 'SYSTEM_TESTS_TEST_DIRECTORY', defaultValue: pipelineDefaults.capsuleSystemTests.systemTestsTestDirectory,
           description: 'Run tests from files in this directory and all sub-directories'),
+      string(name: 'CAPSULE_CONFIG', defaultValue: pipelineDefaults.capsuleSystemTests.capsuleConfig,
+          description: 'Run tests using the given vegacapsule config file'),
       booleanParam(
           name: 'SYSTEM_TESTS_DEBUG', defaultValue: pipelineDefaults.capsuleSystemTests.systemTestsDebug,
           description: 'Enable debug logs for system-tests execution'),
@@ -61,7 +63,7 @@ void call() {
       branchVegawallet: fne(params.VEGAWALLET_BRANCH, pipelineDefaults.capsuleSystemTests.branchVegawallet),
       branchProtos: fne(params.PROTOS_BRANCH, pipelineDefaults.capsuleSystemTests.branchProtos),
       branchVegatools: fne(params.VEGATOOLS_BRANCH, pipelineDefaults.capsuleSystemTests.branchVegatools),
-
+      capsuleConfig: fne(params.CAPSULE_CONFIG, pipelineDefaults.capsuleSystemTests.capsuleConfig),
       systemTestsTestFunction: fne(params.SYSTEM_TESTS_TEST_FUNCTION, pipelineDefaults.capsuleSystemTests.systemTestsTestFunction),
       systemTestsTestMark: fne(params.SYSTEM_TESTS_TEST_MARK, pipelineDefaults.capsuleSystemTests.systemTestsTestMark),
       systemTestsTestDirectory: fne(params.SYSTEM_TESTS_TEST_DIRECTORY, pipelineDefaults.capsuleSystemTests.systemTestsTestDirectory),

--- a/vars/pipelineDefaults.groovy
+++ b/vars/pipelineDefaults.groovy
@@ -59,6 +59,8 @@ Map capsuleSystemTests = [
     branchProtos: 'develop',
     branchVegatools: 'develop',
 
+    capsuleConfig: 'capsule_config.hcl'
+
     systemTestsTestFunction: '',
     systemTestsTestMark: 'smoke',
     systemTestsTestDirectory: '',

--- a/vars/pipelineDefaults.groovy
+++ b/vars/pipelineDefaults.groovy
@@ -59,7 +59,7 @@ Map capsuleSystemTests = [
     branchProtos: 'develop',
     branchVegatools: 'develop',
 
-    capsuleConfig: 'capsule_config.hcl'
+    capsuleConfig: 'capsule_config.hcl',
 
     systemTestsTestFunction: '',
     systemTestsTestMark: 'smoke',

--- a/vars/systemTestsCapsule.groovy
+++ b/vars/systemTestsCapsule.groovy
@@ -20,6 +20,7 @@ void call(Map config = [:]) {
       string(name: 'SYSTEM_TESTS_TEST_FUNCTION', value: config.testFunction ?: pipelineDefaults.capsuleSystemTests.systemTestsTestFunction),
       string(name: 'SYSTEM_TESTS_TEST_MARK', value: config.testMark ?: pipelineDefaults.capsuleSystemTests.systemTestsTestMark),
       string(name: 'SYSTEM_TESTS_TEST_DIRECTORY', value: config.testDirectory ?: pipelineDefaults.capsuleSystemTests.systemTestsTestDirectory),
+      string(name: 'CAPSULE_CONFIG', value: config.capsuleConfig ?: pipelineDefaults.capsuleSystemTests.capsuleConfig),
       booleanParam(
           name: 'SYSTEM_TESTS_DEBUG', value: config.systemTestsDebug ? "${config.systemTestsDebug}".toBoolean() : pipelineDefaults.capsuleSystemTests.systemTestsDebug),
       string(name: 'TIMEOUT', value: config.timeout ? "${config.timeout}" : pipelineDefaults.capsuleSystemTests.systemTestsRunTimeout),


### PR DESCRIPTION
closes #131 

we also now pass in a nomad config to overwrite the default resource caps (and also it kinda makes sense for the system tests repo to be able to control this config)