### PR TITLE
Update default approbation to 2.4.4

### DIFF
--- a/vars/pipelineDefaults.groovy
+++ b/vars/pipelineDefaults.groovy
@@ -136,7 +136,7 @@ Map appr = [
     testsArg: '{./system-tests/tests/**/*.py,./vega/integration/**/*.{go,feature},./MultisigControl/test/*.js}',
     ignoreArg: '{./spec-internal/protocol/0060*,./specs-internal/non-protocol-specs/{0001-NP*,0002-NP*,0004-NP*,0006-NP*,0007-NP*,0008-NP*,0010-NP*}}',
     otherArg: '--show-branches --show-mystery --category-stats --show-files --verbose --output-csv --output-jenkins',
-    approbationVersion: '2.4.3'
+    approbationVersion: '2.4.4'
 ]
 
 @Field


### PR DESCRIPTION
This brings in some minor output changes

- Update `appr.approbationVersion` to 2.4.4 from 2.4.3