### PR TITLE
Fix some small mistakes in stagnet3 pipeline

### DIFF
--- a/vars/capsulePipelineWrapper.groovy
+++ b/vars/capsulePipelineWrapper.groovy
@@ -2,43 +2,43 @@ def call() {
     writeConfigs = { envName ->
         sh label: "generate templates: ${envName}", script: """
             vegacapsule template genesis \
-                --home-path '${CONFIG_HOME}' \
-                --path '${TEMPLATES_HOME}/genesis.tmpl.json' ${FLAGS}
+                --home-path '${env.CONFIG_HOME}' \
+                --path '${env.TEMPLATES_HOME}/genesis.tmpl.json' ${env.FLAGS}
 
             vegacapsule template node-sets \
-                --home-path '${CONFIG_HOME}' \
-                --path '${TEMPLATES_HOME}/vega.validators.tmpl.toml' \
+                --home-path '${env.CONFIG_HOME}' \
+                --path '${env.TEMPLATES_HOME}/vega.validators.tmpl.toml' \
                 --nodeset-group-name validators \
                 --type vega \
-                --with-merge ${FLAGS}
+                --with-merge ${env.FLAGS}
 
             vegacapsule template node-sets \
-                --home-path '${CONFIG_HOME}' \
-                --path '${TEMPLATES_HOME}/tendermint.validators.tmpl.toml' \
+                --home-path '${env.CONFIG_HOME}' \
+                --path '${env.TEMPLATES_HOME}/tendermint.validators.tmpl.toml' \
                 --nodeset-group-name validators \
                 --type tendermint \
-                --with-merge ${FLAGS}
+                --with-merge ${env.FLAGS}
 
             vegacapsule template node-sets \
-                --home-path '${CONFIG_HOME}' \
-                --path '${TEMPLATES_HOME}/vega.full.tmpl.toml' \
+                --home-path '${env.CONFIG_HOME}' \
+                --path '${env.TEMPLATES_HOME}/vega.full.tmpl.toml' \
                 --nodeset-group-name full \
                 --type vega \
-                --with-merge ${FLAGS}
+                --with-merge ${env.FLAGS}
 
             vegacapsule template node-sets \
-                --home-path '${CONFIG_HOME}' \
-                --path '${TEMPLATES_HOME}/tendermint.full.tmpl.toml' \
+                --home-path '${env.CONFIG_HOME}' \
+                --path '${env.TEMPLATES_HOME}/tendermint.full.tmpl.toml' \
                 --nodeset-group-name full \
                 --type tendermint \
-                --with-merge ${FLAGS}
+                --with-merge ${env.FLAGS}
 
             vegacapsule template node-sets \
-                --home-path '${CONFIG_HOME}' \
-                --path '${TEMPLATES_HOME}/data_node.full.tmpl.toml' \
+                --home-path '${env.CONFIG_HOME}' \
+                --path '${env.TEMPLATES_HOME}/data_node.full.tmpl.toml' \
                 --nodeset-group-name full \
                 --type data-node \
-                --with-merge ${FLAGS}
+                --with-merge ${env.FLAGS}
             """
     }
 

--- a/vars/capsulePipelineWrapper.groovy
+++ b/vars/capsulePipelineWrapper.groovy
@@ -2,40 +2,40 @@ def call() {
     writeConfigs = { envName ->
         sh label: "generate templates: ${envName}", script: """
             vegacapsule template genesis \
-                --home-path '""" + CONFIG_HOME + """' \
-                --path '""" + TEMPLATES_HOME + """/genesis.tmpl.json' ${FLAGS}
+                --home-path '${CONFIG_HOME}' \
+                --path '${TEMPLATES_HOME}/genesis.tmpl.json' ${FLAGS}
 
             vegacapsule template node-sets \
-                --home-path '""" + CONFIG_HOME + """' \
-                --path '""" + TEMPLATES_HOME + """/vega.validators.tmpl.toml' \
+                --home-path '${CONFIG_HOME}' \
+                --path '${TEMPLATES_HOME}/vega.validators.tmpl.toml' \
                 --nodeset-group-name validators \
                 --type vega \
                 --with-merge ${FLAGS}
 
             vegacapsule template node-sets \
-                --home-path '""" + CONFIG_HOME + """' \
-                --path '""" + TEMPLATES_HOME + """/tendermint.validators.tmpl.toml' \
+                --home-path '${CONFIG_HOME}' \
+                --path '${TEMPLATES_HOME}/tendermint.validators.tmpl.toml' \
                 --nodeset-group-name validators \
                 --type tendermint \
                 --with-merge ${FLAGS}
 
             vegacapsule template node-sets \
-                --home-path '""" + CONFIG_HOME + """' \
-                --path '""" + TEMPLATES_HOME + """/vega.full.tmpl.toml' \
+                --home-path '${CONFIG_HOME}' \
+                --path '${TEMPLATES_HOME}/vega.full.tmpl.toml' \
                 --nodeset-group-name full \
                 --type vega \
                 --with-merge ${FLAGS}
 
             vegacapsule template node-sets \
-                --home-path '""" + CONFIG_HOME + """' \
-                --path '""" + TEMPLATES_HOME + """/tendermint.full.tmpl.toml' \
+                --home-path '${CONFIG_HOME}' \
+                --path '${TEMPLATES_HOME}/tendermint.full.tmpl.toml' \
                 --nodeset-group-name full \
                 --type tendermint \
                 --with-merge ${FLAGS}
 
             vegacapsule template node-sets \
-                --home-path '""" + CONFIG_HOME + """' \
-                --path '""" + TEMPLATES_HOME + """/data_node.full.tmpl.toml' \
+                --home-path '${CONFIG_HOME}' \
+                --path '${TEMPLATES_HOME}/data_node.full.tmpl.toml' \
                 --nodeset-group-name full \
                 --type data-node \
                 --with-merge ${FLAGS}
@@ -145,7 +145,6 @@ def call() {
                     stage('Sync remote state to local') {
                         steps {
                             sh """
-                            set -x;
                                 mkdir -p '${env.CONFIG_HOME}'
                                 aws s3 sync '${env.S3_CONFIG_HOME}/' '${env.CONFIG_HOME}/'
                             """


### PR DESCRIPTION
### Changes

- Wrapped paths in slashes(`'`), which are required if the working directory in Jenkins contains space.
- Moved `sync local to remote` step, because we need to sync at very end of the pipeline when all steps are finished.


### Tests

Passed pipeline: https://jenkins.ops.vega.xyz/job/private/job/Deployments/job/Vegacapsule/job/Stagnet%203/16/console

Failed pipelines: All pipelines before 15:  https://jenkins.ops.vega.xyz/job/private/job/Deployments/job/Vegacapsule/job/Stagnet%203/