### PR TITLE
Make approbation to run against vegaprotocol/specs

### DIFF
--- a/vars/pipelineApprobation.groovy
+++ b/vars/pipelineApprobation.groovy
@@ -23,8 +23,8 @@ void call() {
                 name: 'VEGA_CORE_BRANCH', defaultValue: pipelineDefaults.appr.vegaCoreBranch,
                 description: 'Git branch, tag or hash of the vegaprotocol/vega repository'),
             string(
-                name: 'SPECS_INTERNAL_BRANCH', defaultValue: pipelineDefaults.appr.specsInternalBranch,
-                description: 'Git branch, tag or hash of the vegaprotocol/specs-internal repository'),
+                name: 'SPECS_BRANCH', defaultValue: pipelineDefaults.appr.specsBranch,
+                description: 'Git branch, tag or hash of the vegaprotocol/specs repository'),
             string(
                 name: 'MULTISIG_CONTROL_BRANCH', defaultValue: pipelineDefaults.appr.multisigControlBranch,
                 description: 'Git branch, tag or hash of the vegaprotocol/MultisigControl repository'),
@@ -75,9 +75,9 @@ void call() {
                                     gitClone('vega', params.VEGA_CORE_BRANCH)
                                 }
                             },
-                            'specs-internal': {
-                                dir('specs-internal') {
-                                    gitClone('specs-internal', params.SPECS_INTERNAL_BRANCH)
+                            'specs': {
+                                dir('specs') {
+                                    gitClone('specs', params.SPECS_BRANCH)
                                 }
                             },
                             'MultisigControl': {

--- a/vars/pipelineDefaults.groovy
+++ b/vars/pipelineDefaults.groovy
@@ -129,12 +129,12 @@ Map fair = [
 @Field
 Map appr = [
     vegaCoreBranch: 'develop',
-    specsInternalBranch: 'master',
+    specsBranch: 'master',
     multisigControlBranch: 'develop',
     systemTestsBranch: 'develop',
-    specsArg: '{./specs-internal/protocol/**/*.{md,ipynb},./specs-internal/non-protocol-specs/**/*.{md,ipynb}}',
+    specsArg: '{./specs/protocol/**/*.{md,ipynb},./specs/non-protocol-specs/**/*.{md,ipynb}}',
     testsArg: '{./system-tests/tests/**/*.py,./vega/integration/**/*.{go,feature},./MultisigControl/test/*.js}',
-    ignoreArg: '{./spec-internal/protocol/0060*,./specs-internal/non-protocol-specs/{0001-NP*,0002-NP*,0004-NP*,0006-NP*,0007-NP*,0008-NP*,0010-NP*}}',
+    ignoreArg: '{./spec-internal/protocol/0060*,./specs/non-protocol-specs/{0001-NP*,0002-NP*,0004-NP*,0006-NP*,0007-NP*,0008-NP*,0010-NP*}}',
     otherArg: '--show-branches --show-mystery --category-stats --show-files --verbose --output-csv --output-jenkins',
     approbationVersion: '2.4.7'
 ]


### PR DESCRIPTION
- Update pipelineApprobation.groovy to rename variables
- Update pipelineDefaults to use new variables & default to specs

vegaprotocol/specs-internal is being made public, replacing the old
vegaprotocol/specs repo. The latter was just a mirror of the former with
some files filtered out - we no longer feel it is required, so we're
just replacing one with the other. This PR updates the variable names
and defaults related to the repo that approbation runs against.
