### PR TITLE
fix: fix issues for cloning vega core and build binaries

### DIFF
--- a/vars/capsulePipelineWrapper.groovy
+++ b/vars/capsulePipelineWrapper.groovy
@@ -233,7 +233,7 @@ void call(Map customConfig = [:]) {
           stage('Download data-node binary from Github Release') {
             when {
               expression {
-                !isS3Link(params.DATA_NODE_VERSION) && params.BUILD_DATA_NODE_BINARY
+                !isS3Link(params.DATA_NODE_VERSION) && !params.BUILD_DATA_NODE_BINARY
               }
             }
 


### PR DESCRIPTION
# Changes

- I have updated the procedure of building binaries from the cloned repository
- Fixed a small typo in the devnet2 pipeline
- Now cloning vega(for vega and data-node) is not parallel to avoid:
  - Conflict when we use the same version
  - Cloning the same repo versions to different folders