### PR TITLE
chore: update approbation version

### DIFF
--- a/vars/pipelineDefaults.groovy
+++ b/vars/pipelineDefaults.groovy
@@ -141,7 +141,7 @@ Map appr = [
     testsArg: '{./system-tests/tests/**/*.py,./vega/core/integration/**/*.{go,feature},./MultisigControl/test/*.js}',
     ignoreArg: '{./spec-internal/protocol/0060*,./specs/non-protocol-specs/{0001-NP*,0002-NP*,0004-NP*,0006-NP*,0007-NP*,0008-NP*,0010-NP*}}',
     otherArg: '--show-branches --show-mystery --category-stats --show-files --verbose --output-csv --output-jenkins --show-file-stats',
-    approbationVersion: '2.6.4'
+    approbationVersion: '2.6.5'
 ]
 
 @Field

--- a/vars/pipelineDefaults.groovy
+++ b/vars/pipelineDefaults.groovy
@@ -141,7 +141,7 @@ Map appr = [
     testsArg: '{./system-tests/tests/**/*.py,./vega/core/integration/**/*.{go,feature},./MultisigControl/test/*.js}',
     ignoreArg: '{./spec-internal/protocol/0060*,./specs/non-protocol-specs/{0001-NP*,0002-NP*,0004-NP*,0006-NP*,0007-NP*,0008-NP*,0010-NP*}}',
     otherArg: '--show-branches --show-mystery --category-stats --show-files --verbose --output-csv --output-jenkins --show-file-stats',
-    approbationVersion: '2.6.3'
+    approbationVersion: '2.6.4'
 ]
 
 @Field


### PR DESCRIPTION
Now that https://github.com/vegaprotocol/approbation/pull/53 has been merged I will create a new tag and then request that this is reviewed and merged in order to get the latest priorities updated

## UPDATE:

Needs to wait until: https://github.com/vegaprotocol/approbation/pull/55 is merged and the 2.6.5 tag is created.