### PR TITLE
fix devnet deployment pipeline

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -143,6 +143,7 @@ veganetParamsBase = {
     stringParam('DEVOPSSCRIPTS_BRANCH', 'main', 'Git branch, tag or hash of the vegaprotocol/devopsscripts repository')
     stringParam('ANSIBLE_BRANCH', 'master', 'Git branch, tag or hash of the vegaprotocol/ansible repository')
     stringParam('JENKINS_SHARED_LIB_BRANCH', 'main', 'Branch of jenkins-shared-library from which pipeline should be run')
+    stringParam('K8S_BRANCH', 'main', 'Branch of k8s repository')
 }
 
 veganetParams = veganetParamsBase << {


### PR DESCRIPTION
# Description

Pipeline is failing when it's triggered manually on branch different than development. For example on the PR.


### Errors

##### 1. environment variable defined in the global `environemnt{}` block can be override only with the `withEnv` block, but We were trying to override it (I mean `env.DOCKER_IMAGE_TAG_HASH`

##### 2. vegawallet and faucet has flag `makeCheckout: false,`. With that flag we assume repository was already pulled and checked out to correct branch. It has not.

##### 3. docker run had a -it flag which assumes, that terminal is in interactive mode, which is not true in that pipeline

##### 4. `timeout` and `waitUntil` blocks in the `doesDockerImageExist` were throwing errors which were causing pipeline to fail. This situation had never happen when deployment is triggered for the `develop` branch because the docker-image has been built in the different pipeline(here: https://github.com/vegaprotocol/vega/blob/develop/Jenkinsfile#L548)

