### PR TITLE
chore: bump approbation version

### DIFF
--- a/vars/pipelineDefaults.groovy
+++ b/vars/pipelineDefaults.groovy
@@ -141,7 +141,7 @@ Map appr = [
     testsArg: '{./system-tests/tests/**/*.py,./vega/core/integration/**/*.{go,feature},./MultisigControl/test/*.js}',
     ignoreArg: '{./spec-internal/protocol/0060*,./specs/non-protocol-specs/{0001-NP*,0002-NP*,0004-NP*,0006-NP*,0007-NP*,0008-NP*,0010-NP*}}',
     otherArg: '--show-branches --show-mystery --category-stats --show-files --verbose --output-csv --output-jenkins --show-file-stats',
-    approbationVersion: '2.6.5'
+    approbationVersion: '2.7.1'
 ]
 
 @Field


### PR DESCRIPTION
Bumps version for the changes required in:

resolves vegaprotocol/specs#1282

DO NOT MEREGE UNTIL THIS HAS BEEN:
- https://github.com/vegaprotocol/approbation/pull/58

and a new tag for 2.7.1 has been created in https://github.com/vegaprotocol/approbation