### PR TITLE
Update approbation to 4.0.0, add new parameter

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -279,6 +279,13 @@ def approbationParams(def config=[:]) {
         }
 
         if (config.type == 'core') {
+            stringParam('CATEGORIES_ARG', './specs/protocol/categories.json', '--categories argument value')
+        }
+        else if (config.type == 'frontend') {
+            stringParam('CATEGORIES_ARG', 'specs/user-interface/categories.json', '--categories argument value')
+        }
+      
+        if (config.type == 'core') {
             stringParam('TESTS_ARG',  '{./system-tests/tests/**/*.py,./vega/core/integration/**/*.{go,feature},./MultisigControl/test/*.js}', '--tests argument value')
         }
         else if (config.type == 'frontend') {
@@ -296,7 +303,7 @@ def approbationParams(def config=[:]) {
             stringParam('OTHER_ARG', '--categories="./specs/user-interface/categories.json" --category-stats --show-branches --verbose --show-files --output-jenkins', 'Other arguments')
         }
 
-        stringParam('APPROBATION_VERSION', '2.7.1', 'Released version of Approbation. latest can be used')
+        stringParam('APPROBATION_VERSION', '4.0.0', 'Released version of Approbation. latest can be used')
 
         stringParam('JENKINS_SHARED_LIB_BRANCH', 'main', 'Branch of jenkins-shared-library from which pipeline should be run')
     }

--- a/vars/pipelineApprobation.groovy
+++ b/vars/pipelineApprobation.groovy
@@ -134,6 +134,7 @@ void call(def config=[:]) {
                         npx @vegaprotocol/approbation@${params.APPROBATION_VERSION} check-references \
                             --specs="${params.SPECS_ARG}" \
                             --tests="${params.TESTS_ARG}" \
+                            --categories="${params.CATEGORIES_ARG}" \
                             ${params.IGNORE_ARG ? "--ignore='${params.IGNORE_ARG}'" : '' } ${params.OTHER_ARG}
                     """
                 }


### PR DESCRIPTION
Approbation 4.0.0 (https://www.npmjs.com/package/@vegaprotocol/approbation/v/4.0.0) adds a new parameter (`--categories`) that is required, and points to a `.json` file in the spec repo. This PR bumps the required version of approbation, and also adds the new parameter, tailored to whether it is core or frontend

- Update approbation version
- Add new stringParam `categories`
- Update pipeline to pass in new param

Closes #296 