### PR TITLE
chore: expand frontend approbation test globs

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -289,7 +289,7 @@ def approbationParams(def config=[:]) {
             stringParam('TESTS_ARG',  '{./system-tests/tests/**/*.py,./vega/core/integration/**/*.{go,feature},./MultisigControl/test/*.js}', '--tests argument value')
         }
         else if (config.type == 'frontend') {
-            stringParam('TESTS_ARG', '{frontend-monorepo/apps/*-e2e/**/*.cy.js,vegawallet-desktop/frontend/automation/cypress/**/*.cy.js}', '--tests argument value')
+          stringParam('TESTS_ARG', '{frontend-monorepo/apps/*-e2e/**/*.cy.{ts,js,tsx,jsx},vegawallet-desktop/frontend/automation/cypress/**/*.cy.{ts,js,tsx,jsx}}', '--tests argument value')
         }
 
         if (config.type == 'core' ) {


### PR DESCRIPTION
Current default configuration for frontend approbation misses some test references as they are in `.cy.ts` files. This PR expands the globs a bit.

- Update test glob to include `.ts`, `.tsx`, `.jsx` as well as `.js`

Closes #299