### PR TITLE
Revert "feat: system-tests  do not stop network on start failure"

### DIFF
--- a/vars/capsuleSystemTests.groovy
+++ b/vars/capsuleSystemTests.groovy
@@ -135,13 +135,7 @@ void call(Map additionalConfig=[:], parametersOverride=[:]) {
               sh 'cp ./vegacapsule/nomad_config.hcl' + ' ' + testNetworkDir + '/nomad_config.hcl'
           }
           dir(testNetworkDir) {
-              sh '''sudo -E daemonize \
-                -o ''' + testNetworkDir + '''/nomad.log \
-                -e ''' + testNetworkDir + '''/nomad.log \
-                -c ''' + testNetworkDir + ''' \
-                -p ''' + testNetworkDir + '''/vegacapsule_nomad.pid \
-                  ''' + testNetworkDir + '''/vegacapsule nomad \
-                      --nomad-config-path=''' + testNetworkDir + '''/nomad_config.hcl'''
+              sh 'daemonize -o ' + testNetworkDir + '/nomad.log -c ' + testNetworkDir + ' -p ' + testNetworkDir + '/vegacapsule_nomad.pid ' + testNetworkDir + '/vegacapsule nomad --nomad-config-path=' + testNetworkDir + '/nomad_config.hcl'
           }
         }
       }
@@ -218,7 +212,7 @@ void call(Map additionalConfig=[:], parametersOverride=[:]) {
               try {
                 timeout(time: 3, unit: 'MINUTES') {
                   sh '''./vegacapsule network start \
-                    --home-path ''' + testNetworkDir + '''/testnet --do-not-stop-on-failure
+                    --home-path ''' + testNetworkDir + '''/testnet
                   '''
                 }
               } finally {


### PR DESCRIPTION
Reverts vegaprotocol/jenkins-shared-library#307


needs debugging why it is failing here: https://jenkins.ops.vega.xyz/job/common/job/system-tests-wrapper/19743/console