### PR TITLE
feat: exclude vega socket and de-history files from archive

### DIFF
--- a/vars/capsuleSystemTests.groovy
+++ b/vars/capsuleSystemTests.groovy
@@ -365,6 +365,10 @@ void call(Map additionalConfig=[:], parametersOverride=[:]) {
         dir(testNetworkDir) {
           archiveArtifacts(
             artifacts: 'testnet/**/*',
+            excludes: [
+              'testnet/**/*.sock',
+              'testnet/data/**/state/data-node/dehistory'
+            ].join(','),
             allowEmptyArchive: true
           )
           archiveArtifacts(

--- a/vars/capsuleSystemTests.groovy
+++ b/vars/capsuleSystemTests.groovy
@@ -295,7 +295,7 @@ void call(Map additionalConfig=[:], parametersOverride=[:]) {
             Map runStages = [
               'run system-tests': {
                 dir('system-tests/scripts') {
-                    sh 'make test'
+                  sh 'make test'
                 }
               }
             ]
@@ -367,7 +367,7 @@ void call(Map additionalConfig=[:], parametersOverride=[:]) {
             artifacts: 'testnet/**/*',
             excludes: [
               'testnet/**/*.sock',
-              'testnet/data/**/state/data-node/dehistory'
+              'testnet/data/**/state/data-node/**/*'
             ].join(','),
             allowEmptyArchive: true
           )


### PR DESCRIPTION
Archiving of the state for data node is skipped: https://jenkins.ops.vega.xyz/job/common/job/system-tests-wrapper/20733/artifact/testnet/data/