### PR TITLE
fix: fix the post-always-action

### DIFF
--- a/vars/pipelineCapsuleSystemTests.groovy
+++ b/vars/pipelineCapsuleSystemTests.groovy
@@ -162,10 +162,5 @@ void call() {
         }
       }
     }
-    post {
-      always {
-        cleanWs()
-      }
-    }
   }
 }


### PR DESCRIPTION
# motivation of change

We do not need to call `cleanWs()` because there is nothing to clean after this pipeline. It cleans the workspace on the jenkins agent but here we do not have any jenkins agent, so no trashes are produced

Triggered build: https://jenkins.ops.vega.xyz/job/common/job/system-tests/13186/console