### PR TITLE
chore: update approbation version

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -341,7 +341,7 @@ def approbationParams(def config=[:]) {
             stringParam('OTHER_ARG', '--category-stats --show-branches --verbose --show-files --output-jenkins  --output-csv', 'Other arguments')
         }
 
-        stringParam('APPROBATION_VERSION', '4.0.0', 'Released version of Approbation. latest can be used')
+        stringParam('APPROBATION_VERSION', '4.2.0', 'Released version of Approbation. latest can be used')
 
         stringParam('JENKINS_SHARED_LIB_BRANCH', 'main', 'Branch of jenkins-shared-library from which pipeline should be run')
     }


### PR DESCRIPTION
The brings the approbation run up to the latest version.

part of: vegaprotocol/approbation#68

This should not be merged until the above issus is closed and the 4.2.0 tag is created on the approbation repo