### PR TITLE
chore: make approbation always run on latest

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -342,7 +342,7 @@ def approbationParams(def config=[:]) {
             stringParam('OTHER_ARG', '--category-stats --show-branches --verbose --show-files --output-jenkins  --output-csv', 'Other arguments')
         }
 
-        stringParam('APPROBATION_VERSION', '4.2.0', 'Released version of Approbation. latest can be used')
+        stringParam('APPROBATION_VERSION', 'latest', 'Released version of Approbation. latest can be used')
 
         stringParam('JENKINS_SHARED_LIB_BRANCH', 'main', 'Branch of jenkins-shared-library from which pipeline should be run')
     }


### PR DESCRIPTION
I just updated the parameter where the version number was to be latest. Reason:

1. We may want to revert back to using a specific version quickly

2. we could remove the param and add `latest` into [here](https://github.com/vegaprotocol/jenkins-shared-library/blob/9be4eeeed91082767e8208056a1d5829f0cd3894/vars/pipelineApprobation.groovy#L134) but that seemed final and I was not sure of any consequences of doing this without me having some local way of testing.

cc @edd