### PR TITLE
chore: add smart contract repos to approbation

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -311,7 +311,7 @@ def approbationParams(def config=[:]) {
         }
 
         if (config.type == 'core') {
-            stringParam('TESTS_ARG',  '{./system-tests/tests/**/*.py,./vega/core/integration/**/*.{go,feature},./MultisigControl/test/*.js}', '--tests argument value')
+            stringParam('TESTS_ARG',  '{./system-tests/tests/**/*.py,./vega/core/integration/**/*.{go,feature},./MultisigControl/test/*.js,./Vega_Token_V2/test/*.js,./Staking_Bridge/test/*.js}', '--tests argument value')
         }
         else if (config.type == 'frontend') {
             stringParam('TESTS_ARG', '{frontend-monorepo/apps/*-e2e/**/*.cy.{ts,js,tsx,jsx},vegawallet-desktop/frontend/automation/cypress/**/*.cy.{ts,js,tsx,jsx}}', '--tests argument value')

--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -285,6 +285,8 @@ def approbationParams(def config=[:]) {
             stringParam('ORIGIN_REPO', 'vegaprotocol/vega', 'repo which acts as source of vegaprotocol (used for forks builds)')
             stringParam('VEGA_CORE_BRANCH', 'develop', 'Git branch, tag or hash of the origin repo repository')
             stringParam('MULTISIG_CONTROL_BRANCH', 'develop', 'Git branch, tag or hash of the vegaprotocol/MultisigControl repository')
+            stringParam('VEGA_TOKEN_V2_BRANCH', 'main', 'Git branch, tag or hash of the vegaprotocol/Vega_Token_V2 repository')
+            stringParam('STAKING_BRIDGE_BRANCH', 'main', 'Git branch, tag or hash of the vegaprotocol/Staking_Bridge repository')
             stringParam('SYSTEM_TESTS_BRANCH', 'develop', 'Git branch, tag or hash of the vegaprotocol/system-tests repository')
         }
         else if (config.type == 'frontend') {

--- a/vars/pipelineApprobation.groovy
+++ b/vars/pipelineApprobation.groovy
@@ -78,6 +78,40 @@ void call(def config=[:]) {
                             sh "rm -rf MultisigControl@tmp"
                         }
                     }
+                    }
+                    stage('Vega_Token_V2') {
+                        when {
+                            expression {
+                                config.type == 'core'
+                            }
+                        }
+                        steps {
+                            gitClone(
+                                directory: 'Vega_Token_V2',
+                                vegaUrl: 'Vega_Token_V2',
+                                branch: "*/${params.VEGA_TOKEN_V2_BRANCH}",
+                                extensions: [[$class: 'LocalBranch', localBranch: "**" ]]
+                            )
+                            sh "rm -rf Vega_Token_V2@tmp"
+                        }
+                    }
+                    }
+                    stage('Staking_Bridge') {
+                        when {
+                            expression {
+                                config.type == 'core'
+                            }
+                        }
+                        steps {
+                            gitClone(
+                                directory: 'Staking_Bridge',
+                                vegaUrl: 'Staking_Bridge',
+                                branch: "*/${params.STAKING_BRIDGE_BRANCH}",
+                                extensions: [[$class: 'LocalBranch', localBranch: "**" ]]
+                            )
+                            sh "rm -rf Staking_Bridge@tmp"
+                        }
+                    }
                     stage('system-tests') {
                         when {
                             expression {

--- a/vars/pipelineApprobation.groovy
+++ b/vars/pipelineApprobation.groovy
@@ -78,7 +78,6 @@ void call(def config=[:]) {
                             sh "rm -rf MultisigControl@tmp"
                         }
                     }
-                    }
                     stage('Vega_Token_V2') {
                         when {
                             expression {
@@ -94,7 +93,6 @@ void call(def config=[:]) {
                             )
                             sh "rm -rf Vega_Token_V2@tmp"
                         }
-                    }
                     }
                     stage('Staking_Bridge') {
                         when {


### PR DESCRIPTION
In order to cover the spec ACs in [0071-STAK-erc20_governance_token_staking.md](https://github.com/vegaprotocol/specs/blob/master/protocol/0071-STAK-erc20_governance_token_staking.md)

This [system test issue](https://github.com/vegaprotocol/system-tests/issues/729) was created. A number of the tests have been written in truffle and in the smart contract repos:

- https://github.com/vegaprotocol/Vega_Token_V2/pull/14
- https://github.com/vegaprotocol/Staking_Bridge/pull/9

These ACs have been tagged in the tests in the above repo code, however, are not showing in the [coverage report](https://jenkins.ops.vega.xyz/blue/rest/organizations/jenkins/pipelines/common/pipelines/approbation/runs/1809/nodes/128/steps/129/log/?start=0)

@edd / @vegaprotocol/ops I have left this PR as a draft as I'm not 100% sure this is all that is required. Please can you have a look / review and if OK I will make ready-for-review etc... If this misses anything I will create an issue and get this scheduled in as required.