### PR TITLE
feat: bump jenkins ami to v0.3.1

### DIFF
--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -5,7 +5,7 @@ x-instance-template: &instance-template
     - name: "tag:Name"
       values: "jenkins-agent"
     - name: "tag:Version"
-      values: "v0.3.0"
+      values: "v0.3.1"
   amiOwners: "355206837991"
   amiType:
     unixData:


### PR DESCRIPTION
We need new ami because the old one has no account role applied which disallow users to ssh into the boxes