### PR TITLE
feat: do not archive vega binaries after system-tests

### DIFF
--- a/vars/capsuleSystemTests.groovy
+++ b/vars/capsuleSystemTests.groovy
@@ -528,7 +528,10 @@ void call(Map additionalConfig=[:], parametersOverride=[:]) {
             artifacts: 'testnet/**/*',
             excludes: [
               'testnet/**/*.sock',
-              'testnet/data/**/state/data-node/**/*'
+              'testnet/data/**/state/data-node/**/*',
+              // do not archive vega binaries
+              'testnet/visor/**/vega',
+              'testnet/visor/**/data-node',
             ].join(','),
             allowEmptyArchive: true
           )


### PR DESCRIPTION
Initially exactly the same change has been implemented for visor pup automatic download test. 

Triggered pipelines:

- https://jenkins.ops.vega.xyz/job/private/job/playgrounds/job/pup-testing/48/  - visor pup automatic download - passed
- https://jenkins.ops.vega.xyz/job/common/job/system-tests-nightly/714/ - nightly
- https://jenkins.ops.vega.xyz/job/common/job/system-tests-wrapper/ - some subset of system-tests