### PR TITLE
chore: don't wait for vegawallet in Protocol Upgrade pipeline

### DIFF
--- a/vars/pipelineVegavisorProtocolUpgradeNetwork.groovy
+++ b/vars/pipelineVegavisorProtocolUpgradeNetwork.groovy
@@ -155,7 +155,8 @@ void call() {
                                 makeCheckout: false,
                                 version: DOCKER_VERSION,
                                 forceRestart: false,
-                                timeout: 20,
+                                timeout: 5,
+                                wait: false,
                             )
                         }
                     }


### PR DESCRIPTION
closes vegaprotocol/devops-infra#1726