### PR TITLE
chore: disable backing up snapshots for Fairground network

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -960,7 +960,7 @@ def jobs = [
         parameters: {
             stringParam('TIMEOUT', '10', 'Number of minutes after which the node will stop')
             stringParam('JENKINS_SHARED_LIB_BRANCH', 'main', 'Branch of jenkins-shared-library from which pipeline should be run')
-            booleanParam('BACKUP_SNAPSHOTS', true, 'Backup the latest snapshots in the vegaprotocol/snapshot-backups repository')
+            booleanParam('BACKUP_SNAPSHOTS', false, 'Backup the latest snapshots in the vegaprotocol/snapshot-backups repository')
         },
         daysToKeep: 4,
         definition: libDefinition('pipelineSnapshotTesting()'),


### PR DESCRIPTION
Disable it temporarily, cos this step always fails. We can re-enable it once we find and fix the issue.