### PR TITLE
build(approbation): use latest from github always

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -332,8 +332,6 @@ def approbationParams(def config=[:]) {
             stringParam('OTHER_ARG', '--category-stats --show-branches --verbose --show-files --output-jenkins  --output-csv', 'Other arguments')
         }
 
-        stringParam('APPROBATION_VERSION', 'latest', 'Released version of Approbation. latest can be used')
-
         stringParam('JENKINS_SHARED_LIB_BRANCH', 'main', 'Branch of jenkins-shared-library from which pipeline should be run')
     }
 }

--- a/vars/pipelineApprobation.groovy
+++ b/vars/pipelineApprobation.groovy
@@ -163,7 +163,7 @@ void call(def config=[:]) {
             stage('Run Approbation') {
                 steps {
                     sh label: 'approbation', script: """#!/bin/bash -e
-                        npx @vegaprotocol/approbation@${params.APPROBATION_VERSION} check-references \
+                        npx --yes --silent github:vegaprotocol/approbation check-references \
                             --specs="${params.SPECS_ARG}" \
                             --tests="${params.TESTS_ARG}" \
                             --categories="${params.CATEGORIES_ARG}" \


### PR DESCRIPTION
Switches from using NPM as the source of approbation to Github, without a version spec as we always use latest

- Update `Run Approbation` stage

This was something we had planned to do for a while, but was triggered when 4.3.4 was tagged with a tag that didn't match the expected format, causing 4.3.4 not to be published to npm, leading to confusion as to why it wasn't running the latest code.

Closes #414