### PR TITLE
build(frontend): configure a second approbation run for frontend

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -313,7 +313,8 @@ def approbationParams(def config=[:]) {
             stringParam('CATEGORIES_ARG', './specs/protocol/categories.json', '--categories argument value')
         }
         else if (config.type == 'frontend') {
-            stringParam('CATEGORIES_ARG', 'specs/user-interface/categories.json', '--categories argument value')
+            stringParam('CATEGORIES_ARG', 'specs/user-interface/categories.json', '--categories argument value for the categories run')
+            stringParam('APPS_ARG', 'specs/user-interface/apps.json', '--categories argument value for the apps run')
         }
 
         if (config.type == 'core') {

--- a/vars/pipelineApprobation.groovy
+++ b/vars/pipelineApprobation.groovy
@@ -160,7 +160,7 @@ void call(def config=[:]) {
                     }
                 }
             }
-            stage('Run Approbation') {
+            stage('Run Approbation: Categories') {
                 steps {
                     sh label: 'approbation', script: """#!/bin/bash -e
                         npx --yes --silent github:vegaprotocol/approbation check-references \
@@ -171,6 +171,22 @@ void call(def config=[:]) {
                     """
                 }
             }
+            stage('Run Approbation: Apps') {
+                    when {
+                        expression {
+                            config.type == 'frontend'
+                        }
+                    }
+                    steps {
+                        sh label: 'approbation', script: """#!/bin/bash -e
+                            npx --yes --silent github:vegaprotocol/approbation check-references \
+                                --specs="${params.SPECS_ARG}" \
+                                --tests="${params.TESTS_ARG}" \
+                                --categories="${params.APPS_ARG}" \
+                                ${params.IGNORE_ARG ? "--ignore='${params.IGNORE_ARG}'" : '' } ${params.OTHER_ARG}
+                        """
+                    }
+                }
         }
         post {
             always {


### PR DESCRIPTION
Frontend has two different perspectives for AC coverage, categories and apps

This PR adds a second approbation run for frontend only that takes a new parameter

One potential problem could be that it would overwrite test results. I haven't dealt with that

- Add new paramter
- Add new stage that only runs for frontend

Closes #420

Whoever reviews this - if I have made a terrible error, @pennyandrews knows what I am trying to achieve if I am unavailble.