### PR TITLE
chore: disable top up for extra bots on Stagnet 1

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -577,7 +577,8 @@ def jobs = [
         env: [
             NET_NAME: 'stagnet1',
         ],
-        parameters: vegavisorTopupBotsParams(["2","3","4","5", "6", "7"]),
+        // parameters: vegavisorTopupBotsParams(["2","3","4","5", "6", "7"]),
+        parameters: vegavisorTopupBotsParams(),
         cron: 'H * * * *',
         disableConcurrentBuilds: true,
     ],


### PR DESCRIPTION
closes vegaprotocol/devops-infra#1821