### PR TITLE
chore: point approbation at cosmicelevator branch

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -374,7 +374,7 @@ def approbationParams(def config=[:]) {
             stringParam('VEGAWALLET_BROWSER_BRANCH', 'main', 'Git branch, tag or hash of the vegaprotocol/vegawallet-browser repository')
         }
 
-        stringParam('SPECS_BRANCH', 'master', 'Git branch, tag or hash of the vegaprotocol/specs repository')
+        stringParam('SPECS_BRANCH', 'cosmicelevator', 'Git branch, tag or hash of the vegaprotocol/specs repository')
 
         if (config.type == 'core') {
             stringParam('SPECS_ARG', '{./specs/protocol/**/*.{md,ipynb},./specs/non-protocol-specs/**/*.{md,ipynb}}', '--specs argument value')


### PR DESCRIPTION
In order to make the approbation pipeline point at the `cosmicelevator` branch in the specs repo this PR changes the branch its looking at.

This will allow us to track AC coverage on the cosmicelevator branch during the development/testing of this . 

There is a periodic (manual) task to keep the cosmic elevator branch up-to-date with master which will mean that any changes for Alpha Mainnet specs/ACs will (with a slight lag) get updated and be present in the approbation run.

