### PR TITLE
feat: increase block upgrade for system-tests proposal

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -1016,7 +1016,7 @@ def jobs = [
         useScmDefinition: false,
         definition: libDefinition('pipelineCapsuleLNL()'),
         parameters: lnlSystemTestsparams(
-            NODE_LABEL: 'general',
+            NODE_LABEL: 's-8vcpu-16gb',
         ),
         copyArtifacts: true,
         daysToKeep: 10,

--- a/vars/capsuleSystemTests.groovy
+++ b/vars/capsuleSystemTests.groovy
@@ -561,7 +561,7 @@ void call(Map additionalConfig=[:], parametersOverride=[:]) {
 
         steps {
           script {
-            int upgradeProposalOffset = 100
+            int upgradeProposalOffset = 200
             def getLastBlock = { boolean silent ->
               return vegautils.shellOutput('''devopsscripts vegacapsule last-block \
                   --output value-only \


### PR DESCRIPTION
Changes:

- Change the machine to DO, because AWS machines are burstable and it causes many issues when there is no CPU credit for the machine that runs the LNL pipeline.
- We increased the number of block to use for protocol upgrade. It is required because sometimes data-node is behind and reports not the latest block