### PR TITLE
feat: clone capsule in vega-market-sim job

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -1183,6 +1183,7 @@ def jobs = [
         parameters: {
             stringParam('ORIGIN_REPO', 'vegaprotocol/vega', 'repository which acts as vega source code (used for forks builds)')
             stringParam('VEGA_VERSION', 'develop', 'Git branch, tag or hash of the vegaprotocol/vega repository')
+            stringParam('VEGACAPSULE_VERSION', 'main', 'Git branch, tag or hash of the vegaprotocol/vegacapsule repository')
             stringParam('VEGA_MARKET_SIM_BRANCH', 'develop', 'Git branch, tag or hash of the vegaprotocol/vega-market-sim repository')
             stringParam('TIMEOUT', '45', 'Number of minutes after which the job will stop')
             booleanParam('RUN_EXTRA_TESTS', false, 'Run extra tests that you don\'t always want to run')
@@ -1201,6 +1202,7 @@ def jobs = [
         parameters: {
             stringParam('ORIGIN_REPO', 'vegaprotocol/vega', 'repository which acts as vega source code (used for forks builds)')
             stringParam('VEGA_VERSION', 'develop', 'Git branch, tag or hash of the vegaprotocol/vega repository')
+            stringParam('VEGACAPSULE_VERSION', 'main', 'Git branch, tag or hash of the vegaprotocol/vegacapsule repository')
             stringParam('VEGA_MARKET_SIM_BRANCH', 'develop', 'Git branch, tag or hash of the vegaprotocol/vega-market-sim repository')
             stringParam('TIMEOUT', '1440', 'Number of minutes after which the job will stop')
             booleanParam('RUN_EXTRA_TESTS', false, 'Run extra tests that you don\'t always want to run')

--- a/vars/pipelineVegaMarketSim.groovy
+++ b/vars/pipelineVegaMarketSim.groovy
@@ -46,6 +46,17 @@ void call() {
                     }
                 }
             }
+            stage('Clone vegacapsule'){    
+                options { retry(3) }
+                steps {
+                    dir('extern/vegacapsule') {
+                        checkout(
+                            [$class: 'GitSCM', branches: [[name: "${params.VEGACAPSULE_VERSION}" ]],
+                            userRemoteConfigs: [[credentialsId: 'vega-ci-bot', url: "git@github.com:vegaprotocol/vegacapsule.git"]]]
+                        )
+                    }
+                }
+            }
             stage('Build Docker Image') {
                 options { retry(3) }
                 when {

--- a/vars/vegaMarketSim.groovy
+++ b/vars/vegaMarketSim.groovy
@@ -15,6 +15,7 @@ void call(Map config = [:]) {
       ),
       string(name: 'ORIGIN_REPO', value: config.originRepo ?: 'vegaprotocol/vega'),
       string(name: 'VEGA_VERSION', value: config.vegaVersion ?: "develop"),
+      string(name: 'VEGACAPSULE_VERSION', value: config.vegacapsuleVersion ?: "main"),
       string(name: 'VEGA_MARKET_SIM_BRANCH', value: config.vegaMarketSim ?: "develop"),
       string(name: 'JENKINS_SHARED_LIB_BRANCH', value: config.jenkinsSharedLib ?: "main"),
       string(name: 'NODE_LABEL', value: config.nodeLabel ?: 'system-tests'),


### PR DESCRIPTION
vega-market-sim tests (which will be added by vegaprotocol/vega-market-sim#411) require `vegacapsule` available on the host. PR adds a stage for cloning `vegacapsule`.