### PR TITLE
feat: add new do instance with python 3-11 for jenkins

### DIFF
--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -96,6 +96,10 @@ jenkins:
         sshKeyId: 35449484
         templates:
           - <<: *do-template
+            labelString: "system-test-capsule-python-3-11-testing-only"
+            sizeId: "s-8vcpu-16gb"
+            imageId: "135114985"
+          - <<: *do-template
             labelString: "s-8vcpu-16gb"
             sizeId: "s-8vcpu-16gb"
           - <<: *do-template


### PR DESCRIPTION
I have built image for testing manually from this branch: https://github.com/vegaprotocol/ansible/pull/582

```

==> Wait completed after 59 minutes 248 milliseconds

==> Builds finished. The artifacts of successful builds are:
--> digitalocean.this: A snapshot was created: 'jenkins-agent-v0-5-0-pre1' (ID: 135114985) in regions 'fra1'
--> digitalocean.this: A snapshot was created: 'jenkins-agent-v0-5-0-pre1' (ID: 135114985) in regions 'fra1'

```