### PR TITLE
feat: add steps for debugging snapshot compatibility

### DIFF
--- a/vars/capsuleSystemTests.groovy
+++ b/vars/capsuleSystemTests.groovy
@@ -717,14 +717,18 @@ void call(Map additionalConfig=[:], parametersOverride=[:]) {
         }
 
         catchError {
-          archiveArtifacts(
-              artifacts: "soak-test/**/**/node-**.log",
-              allowEmptyArchive: true,
-          )
-          archiveArtifacts(
-              artifacts: "soak-test/**/**/err-node-**.log",
-              allowEmptyArchive: true,
-          )
+          script {
+            if (params.RUN_SOAK_TEST) {
+              archiveArtifacts(
+                  artifacts: "soak-test/**/**/node-*.log",
+                  allowEmptyArchive: true,
+              )
+              archiveArtifacts(
+                  artifacts: "soak-test/**/**/err-node-*.log",
+                  allowEmptyArchive: true,
+              )
+            }
+          }
         }
 
         dir(testNetworkDir) {

--- a/vars/pipelineCapsuleSnapshotCompatibility.groovy
+++ b/vars/pipelineCapsuleSnapshotCompatibility.groovy
@@ -74,6 +74,16 @@ void call(Map paramsOverrides=[:]) {
                     '''
                 }
             ],
+            postPipeline: [
+                'Archive snapshots': {
+                    dir('system-tests') {
+                        archiveArtifacts(
+                            artifacts: 'tests/snapshot_compatibility/snapshot-*.json',
+                            allowEmptyArchive: true
+                        )
+                    }
+                }
+            ],
         ],
     ], [
         SKIP_MULTISIGN_SETUP: true,

--- a/vars/pipelineCapsuleSnapshotCompatibility.groovy
+++ b/vars/pipelineCapsuleSnapshotCompatibility.groovy
@@ -59,7 +59,6 @@ void call(Map paramsOverrides=[:]) {
                     dir (pipelineDefaults.capsuleSystemTests.systemTestsNetworkDir) {
                         networkDir = vegautils.escapePath(pwd())
                     }
-                    sleep 30; // todo: move it to golang...
                     sh label: 'Produce snapshot', script: '''
                         devopstools snapshot-compatibility produce-new-snapshot \
                             --vegacapsule-binary "vegacapsule" \
@@ -75,14 +74,11 @@ void call(Map paramsOverrides=[:]) {
                     '''
                 }
             ],
-            preNetworkStop: [
-                'Sleep': {
-                    sleep 7200
-                }
-            ]
         ],
     ], [
         SKIP_MULTISIGN_SETUP: true,
-        RUN_SOAK_TEST: false, // We do not want to run SOAK for the null chain
+        // We do not want to run SOAK for the null chain
+        RUN_PROTOCOL_UPGRADE_PROPOSAL: false,
+        RUN_SOAK_TEST: false,
     ])
 }

--- a/vars/pipelineCapsuleSnapshotCompatibility.groovy
+++ b/vars/pipelineCapsuleSnapshotCompatibility.groovy
@@ -59,6 +59,7 @@ void call(Map paramsOverrides=[:]) {
                     dir (pipelineDefaults.capsuleSystemTests.systemTestsNetworkDir) {
                         networkDir = vegautils.escapePath(pwd())
                     }
+                    sleep 30; // todo: move it to golang...
                     sh label: 'Produce snapshot', script: '''
                         devopstools snapshot-compatibility produce-new-snapshot \
                             --vegacapsule-binary "vegacapsule" \
@@ -73,9 +74,15 @@ void call(Map paramsOverrides=[:]) {
                             --vegacapsule-home "''' + networkDir + '''/testnet"
                     '''
                 }
+            ],
+            preNetworkStop: [
+                'Sleep': {
+                    sleep 7200
+                }
             ]
         ],
     ], [
         SKIP_MULTISIGN_SETUP: true,
+        RUN_SOAK_TEST: false, // We do not want to run SOAK for the null chain
     ])
 }


### PR DESCRIPTION
# Changes

- Disabled SOAK test for snapshot compatibility
- Disable network protocol upgrade test for snapshot compatibility


# Related PRs:

- https://github.com/vegaprotocol/vega/pull/8887
- https://github.com/vegaprotocol/jenkins-shared-library/pull/568
- https://github.com/vegaprotocol/devopstools/pull/53
- https://github.com/vegaprotocol/system-tests/pull/2323


# Triggered builds:

- https://jenkins.ops.vega.xyz/job/common/job/system-tests-snapshot-compatibility/46/
- https://jenkins.ops.vega.xyz/job/common/job/system-tests-snapshot-compatibility/45
- https://jenkins.ops.vega.xyz/job/common/job/system-tests-snapshot-compatibility/43