### PR TITLE
feat: improve fast fail logic

### DIFF
--- a/vars/capsuleSystemTests.groovy
+++ b/vars/capsuleSystemTests.groovy
@@ -481,18 +481,17 @@ void call(Map additionalConfig=[:], parametersOverride=[:]) {
               Map runStages = [
                 'run system-tests': {
                   dir('system-tests/scripts') {
-                    try {
+                    if (config.fastFail) {
+                      // Just execute and fail immediately when something return an error
                       sh 'make test'
-                    } catch(err) {
-                      systmeTestFailed = true
-                      print("FAILURE AFTER make test")
-                      // We have some scenarios, where We do not want to stop pipeline here(e.g. LNL), but we still want to report failure
-                      currentBuild.result = 'FAILURE'
-                      if (!config.fastFail) {
-                        print(err)
-                      } else {
-                        throw err
+                    } else {
+                      // We have some scenarios, where We do not want to stop pipeline here(e.g. LNL), 
+                      // but we still want to report failure for overall build and the stage itself
+                      catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                        sh 'make test'
                       }
+                      
+                      systmeTestFailed = true
                     }
                   }
                 }


### PR DESCRIPTION
There was an issue that the build status was set to `FAULURE` but all stages were green. See the screen below for this job: https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/86804/pipeline/511

![image](https://github.com/vegaprotocol/jenkins-shared-library/assets/1239637/7ca20e1f-89bc-4096-85d3-48e4253d9195)


After the change We can see correct results: 


- Passed results: https://jenkins.ops.vega.xyz/job/common/job/system-tests-wrapper/86818/console
- Failed ste & Stage: https://jenkins.ops.vega.xyz/job/common/job/system-tests-wrapper/86865/console ( see screen below)

![image](https://github.com/vegaprotocol/jenkins-shared-library/assets/1239637/a5efa352-384e-428f-bd79-0f4a1a4a2fa8)
