### PR TITLE
fix: crashing frontend approbation run

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -425,7 +425,7 @@ def approbationParams(def config=[:]) {
             stringParam('VEGAWALLET_BROWSER_BRANCH', 'main', 'Git branch, tag or hash of the vegaprotocol/vegawallet-browser repository')
         }
 
-        stringParam('APPROBATION_TAG', 'v4.5.0', 'Approbation image tag. latest or specific version with v prefix')
+        stringParam('APPROBATION_TAG', 'v4.5.1', 'Approbation image tag. latest or specific version with v prefix')
 
         stringParam('SPECS_BRANCH', 'cosmicelevator', 'Git branch, tag or hash of the vegaprotocol/specs repository')
 


### PR DESCRIPTION
approbation 4.5.0 fails to run properly if `--features` is passed an empty string. This broke frontend approbation runs only, as I defaulted core to a non-empty value.

- Bump default approbation tag to `v4.5.1`