### PR TITLE
fix: default approbation features json

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -448,7 +448,7 @@ def approbationParams(def config=[:]) {
         }
 
         if (config.type == 'core') {
-            stringParam('FEATURES_ARG',  'specs/protocol/features.json', '--features argument value')
+            stringParam('FEATURES_ARG',  '/workspace/specs/protocol/features.json', '--features argument value')
         }
         else if (config.type == 'frontend') {
             stringParam('FEATURES_ARG',  '', '--features argument value')


### PR DESCRIPTION
The default value I put in did not use the docker volume path. 