### PR TITLE
chore: change cron zfs backups to be done on api0

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -1004,7 +1004,7 @@ def jobs = [
         parameterizedCron: [
             // automatic backup every 6h
             'H */6 * * * %' + [
-                'SERVER=api7.vega.community',
+                'SERVER=api0.vega.community',
             ].join(';'),
         ].join('\n'),
     ],


### PR DESCRIPTION
closes vegaprotocol/devops-infra#2008