### PR TITLE
feat: fixes&improvements for cleanup-agents

### DIFF
--- a/vars/pipelineCleanupAgents.groovy
+++ b/vars/pipelineCleanupAgents.groovy
@@ -4,6 +4,7 @@ List<String> dockerImages(){
         "vegaprotocol/vegacapsule-timescaledb:2.8.0-pg14-v0.0.1",
         "vegaprotocol/grpc-plugins:latest",
         "vegaprotocol/clef:v2.2.1",
+        "vegaprotocol/ganache:v1.2.4"
         "golang:1.20-alpine3.18",
         "alpine:3.18",
     ]

--- a/vars/pipelineCleanupAgents.groovy
+++ b/vars/pipelineCleanupAgents.groovy
@@ -96,6 +96,7 @@ void call() {
     pipeline {
         agent none
         options {
+            timeout(time: 120, unit: 'MINUTES')
             timestamps()
             ansiColor('xterm')
         }

--- a/vars/pipelineCleanupAgents.groovy
+++ b/vars/pipelineCleanupAgents.groovy
@@ -111,19 +111,37 @@ void call() {
                                                 .getAssignedLabels()
                                                 .collect {it.toString()}
                                             print('Labels for ' + name + ': ' + labels.join(', '))
+                                            
+                                            retry(count: 3) {
+                                                timeout(time: 10) {
+                                                    _goClean()
+                                                    _systemPackagesUpgrade()
+                                                    _cleanupDocker()
+                                                }
+                                            }
 
-                                            _goClean()
-                                            _systemPackagesUpgrade()
-                                            _cleanupDocker()
-                                            _cacheDockerImages(dockerImages())
+
+                                            retry(count: 3) {
+                                                timeout(time: 5) {
+                                                    _cacheDockerImages(dockerImages())
+                                                }
+                                            }
 
                                             // rebuild cache only for machines that do actual builds
                                             if (!labels.contains('tiny')) {
-                                                _cacheGoBuild(gitRepositories())
+                                                retry(count: 3) {
+                                                    timeout(time: 5) {
+                                                        _cacheGoBuild(gitRepositories())
+                                                    }
+                                                }
                                             }
                                         }
 
-                                        _cleanWorkspaces()
+                                        retry(count: 3) {
+                                            timeout(time: 5) {
+                                                _cleanWorkspaces()
+                                            }
+                                        }
                                         cleanWs()
                                     }
                                 }

--- a/vars/pipelineCleanupAgents.groovy
+++ b/vars/pipelineCleanupAgents.groovy
@@ -83,7 +83,12 @@ void call() {
     String nodeSelector = params.NODE ?: ''
 
     if (nodeSelector.length() < 1) {
-        SLAVES = Jenkins.instance.computers.findAll{ "${it.class}" == "class hudson.slaves.SlaveComputer" }.collect{ it.name }.collate(3)
+        SLAVES = Jenkins
+            .instance
+            .computers
+            .findAll{ "${it.class}" == "class hudson.slaves.SlaveComputer" && it.isOnline() }
+            .collect{ it.name }
+            .collate(3)
     }
     else {
         SLAVES = params.NODE.replaceAll(" ", "").split(",").toList().collate(3)
@@ -115,8 +120,8 @@ void call() {
                                             retry(count: 3) {
                                                 timeout(time: 10) {
                                                     _goClean()
-                                                    _systemPackagesUpgrade()
                                                     _cleanupDocker()
+                                                    _systemPackagesUpgrade()
                                                 }
                                             }
 

--- a/vars/pipelineCleanupAgents.groovy
+++ b/vars/pipelineCleanupAgents.groovy
@@ -88,7 +88,7 @@ void call() {
             .computers
             .findAll{ "${it.class}" == "class hudson.slaves.SlaveComputer" && it.isOnline() }
             .collect{ it.name }
-            .collate(3)
+            .collate(6)
     }
     else {
         SLAVES = params.NODE.replaceAll(" ", "").split(",").toList().collate(3)

--- a/vars/pipelineCleanupAgents.groovy
+++ b/vars/pipelineCleanupAgents.groovy
@@ -128,7 +128,9 @@ void call() {
 
                                             retry(count: 3) {
                                                 timeout(time: 5) {
-                                                    _cacheDockerImages(dockerImages())
+                                                    withDockerLogin('vegaprotocol-dockerhub', true) {
+                                                        _cacheDockerImages(dockerImages())
+                                                    }
                                                 }
                                             }
 

--- a/vars/pipelineCleanupAgents.groovy
+++ b/vars/pipelineCleanupAgents.groovy
@@ -4,7 +4,7 @@ List<String> dockerImages(){
         "vegaprotocol/vegacapsule-timescaledb:2.8.0-pg14-v0.0.1",
         "vegaprotocol/grpc-plugins:latest",
         "vegaprotocol/clef:v2.2.1",
-        "vegaprotocol/ganache:v1.2.4"
+        "vegaprotocol/ganache:v1.2.4",
         "golang:1.20-alpine3.18",
         "alpine:3.18",
     ]

--- a/vars/pipelineCleanupAgents.groovy
+++ b/vars/pipelineCleanupAgents.groovy
@@ -110,15 +110,17 @@ void call() {
                             parallel slavesBatch.collectEntries { name -> [
                                 (name): {
                                     node(name) {
+                                        def labels = Jenkins
+                                            .instance
+                                            .computers
+                                            .find{ "${it.name}" == name }
+                                            .getAssignedLabels()
+                                            .collect {it.toString()}
+                                        print('Labels for ' + name + ': ' + labels.join(', '))
+                                        
+                                        
                                         // We can keep job as UNSTABLE when the cleanup is not finished
                                         catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
-                                            def labels = Jenkins
-                                                .instance
-                                                .computers
-                                                .find{ "${it.name}" == name }
-                                                .getAssignedLabels()
-                                                .collect {it.toString()}
-                                            print('Labels for ' + name + ': ' + labels.join(', '))
                                             
                                             retry(count: 3) {
                                                 timeout(time: 10) {

--- a/vars/pipelineCleanupAgents.groovy
+++ b/vars/pipelineCleanupAgents.groovy
@@ -49,9 +49,9 @@ void _cleanupDocker() {
         sh label: 'Kill all running docker containers', script: 'docker kill $(docker ps -q)'
     }
     if (localImages > 0) {
-        sh label: 'Prune all docker artifacts', script: 'docker system prune --all --force'
+        sh label: 'Prune all docker artifacts', script: 'docker system prune --all --volumes --force'
         sh label: 'Remove all docker images', script: 'docker rmi --force $(docker images -a -q) || echo "All images removed by prune"'
-        sh label: 'Prune all docker artifacts', script: 'docker system prune --all --force'
+        sh label: 'Prune all docker artifacts', script: 'docker system prune --all --volumes --force'
     }
 }
 

--- a/vars/pipelineCleanupAgents.groovy
+++ b/vars/pipelineCleanupAgents.groovy
@@ -97,6 +97,7 @@ void call() {
         agent none
         options {
             timeout(time: 120, unit: 'MINUTES')
+            disableConcurrentBuilds()
             timestamps()
             ansiColor('xterm')
         }

--- a/vars/pipelineCleanupAgents.groovy
+++ b/vars/pipelineCleanupAgents.groovy
@@ -38,9 +38,9 @@ void _cleanWorkspaces() {
 
 void _cleanupDocker() {
     sh label: 'Kill all running docker containers', script: 'docker kill $(docker ps -q)'
-    sh label: 'Prune all docker artifacts': script: 'docker system prune --all --force'
+    sh label: 'Prune all docker artifacts', script: 'docker system prune --all --force'
     sh label: 'Remove all docker images', script: 'docker rmi --force $(docker images -a -q)'
-    sh label: 'Prune all docker artifacts': script: 'docker system prune --all --force'
+    sh label: 'Prune all docker artifacts', script: 'docker system prune --all --force'
 }
 
 void _cacheDockerImages(List<String> images) {


### PR DESCRIPTION
# Changes

- Add more docker images to the cache 
- Fix the docker cleanup steps
- Filter only online computers - ignore offline which stops the job to finish
- Add retry&timeouts to particular steps
- Reorder steps
- Move `cleanWs` into the agent, - we cannot run it in the pipeline because there is no node

# Tested

- https://jenkins.vega.rocks/job/private/job/agents-cleanup/27/ - multiple nodes - failed for the jenkins25, fixed and rerun later(see next link)
- https://jenkins.vega.rocks/job/private/job/agents-cleanup/35/console - single node