### PR TITLE
feat: add nomad metrics for exporter

### DIFF
--- a/resources/grafana-agent-basic.yaml
+++ b/resources/grafana-agent-basic.yaml
@@ -125,6 +125,19 @@ metrics:
                 - __address__
              target_label: instance
 
+       - job_name: nomad
+         metrics_path: /v1/metrics
+         params:
+            format: ['prometheus']
+         static_configs:
+            - targets:
+                - 127.0.0.1:4646
+         relabel_configs:
+           - replacement: ${AGENT_NAME}
+             source_labels:
+                - __address__
+             target_label: instance
+
 integrations:
   agent:
     enabled: true


### PR DESCRIPTION
# Tested here:

- https://jenkins.vega.rocks/job/common/job/system-tests-wrapper/15600/consoleFull
- https://jenkins.vega.rocks/job/common/job/system-tests-wrapper/15630/consoleFull

With that collector i was able to collect memory usage for ganache/postgresql and the CPU usage for network nodes and components like ganache/clef/postgresql


You can check dashboard here:  https://monitoring.vega.community/d/b0d2f7c2-cf92-4487-8349-1f4d30d45e8e/system-tests?orgId=1&var-agent=jenkins-fra1-ubuntu-aaf23212-a723-409a-a936-31ecb85de81f&from=1695808390955&to=1695810315406


<img width="1394" alt="image" src="https://github.com/vegaprotocol/system-tests/assets/1239637/a234c6c7-d627-49d8-a460-1157574bd861">
