### PR TITLE
feat: use new commands from devopstools for snapshot-compatibility pipeline

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -1048,7 +1048,7 @@ def snapshotCompatibilityParams(Map args=[:]) {
         }
         stringParam {
             name('CAPSULE_CONFIG')
-            defaultValue('capsule_config_mainnet_snapshot.hcl')
+            defaultValue('capsule_config_mainnet_snapshot_compatibility_develop.hcl')
             description('Run tests using the given vegacapsule config file')
             trim(true)
         }

--- a/vars/pipelineCapsuleSnapshotCompatibility.groovy
+++ b/vars/pipelineCapsuleSnapshotCompatibility.groovy
@@ -30,15 +30,23 @@ void call(Map paramsOverrides=[:]) {
 
                     withCredentials([sshCredentials]) {
                         print('Random server for snapshot source: ' + selectedMainnetApiServer)
-                        sh label: 'Prepare mainnet genesis', script: '''
-                            devopstools snapshot-compatibility load-snapshot \
+
+                        sh label: 'Download mainnet snapshot', script: '''
+                            devopstools snapshot-compatibility download-mainnet-snapshot \
                                 --snapshot-remote-location "/home/vega/vega_home/state/node/snapshots" \
                                 --snapshot-server "''' + selectedMainnetApiServer + '''" \
                                 --snapshot-server-key-file "''' + PSSH_KEYFILE + '''" \
                                 --snapshot-server-user "''' + PSSH_USER + '''" \
+                                --local-temporary-destination ./mainnet-snapshot
+                        '''
+
+
+                        sh label: 'Load downloaded snapshot into generated network', script: '''
+                            devopstools snapshot-compatibility load-snapshot \
                                 --vegacapsule-binary "vegacapsule" \
                                 --vega-binary "vega" \
-                                --vegacapsule-home "''' + networkDir + '''/testnet"
+                                --vegacapsule-home "''' + networkDir + '''/testnet \
+                                --snapshot-location ./mainnet-snapshot
                         '''
                     }
 

--- a/vars/pipelineCapsuleSnapshotCompatibility.groovy
+++ b/vars/pipelineCapsuleSnapshotCompatibility.groovy
@@ -45,7 +45,7 @@ void call(Map paramsOverrides=[:]) {
                             devopstools snapshot-compatibility load-snapshot \
                                 --vegacapsule-binary "vegacapsule" \
                                 --vega-binary "vega" \
-                                --vegacapsule-home "''' + networkDir + '''/testnet \
+                                --vegacapsule-home "''' + networkDir + '''/testnet" \
                                 --snapshot-location ./mainnet-snapshot
                         '''
                     }


### PR DESCRIPTION


# Related PRs

- https://github.com/vegaprotocol/jenkins-shared-library/pull/690
- https://github.com/vegaprotocol/devopstools/pull/82
- https://github.com/vegaprotocol/system-tests/pull/2839