### PR TITLE
feat: change channel for mainnet snapshot compatibility notifications

### DIFF
--- a/vars/pipelineCapsuleSnapshotCompatibility.groovy
+++ b/vars/pipelineCapsuleSnapshotCompatibility.groovy
@@ -1,8 +1,9 @@
 /* groovylint-disable DuplicateStringLiteral, LineLength */
 void call(Map paramsOverrides=[:]) {
     capsuleSystemTests([
+        slackChannel: '#snapshot-notify',
+        slackTitle: 'Mainnet snapshot compatibility(nullchain network)',
         agentLabel: params.NODE_LABEL ?: '',
-        systemTestsBranch: 'lnl-pipeline',
         extraEnvVars: [
             'NO_DATA_NODE_TEST_CASE': 'true',
             'NULL_BLOCK_CHAIN': 'true',

--- a/vars/pipelineCapsuleSnapshotCompatibility.groovy
+++ b/vars/pipelineCapsuleSnapshotCompatibility.groovy
@@ -2,14 +2,13 @@
 void call(Map paramsOverrides=[:]) {
     capsuleSystemTests([
         slackChannel: '#snapshot-notify',
-        slackTitle: 'Mainnet snapshot compatibility(nullchain network)',
+        slackTitle: 'Mainnet snapshot compatibility(nullchain)',
         agentLabel: params.NODE_LABEL ?: '',
         extraEnvVars: [
             'NO_DATA_NODE_TEST_CASE': 'true',
             'NULL_BLOCK_CHAIN': 'true',
         ],
         fastFail: false,
-        slackTitle: 'LNL Mainnet System Tests',
         hooks: [
             postNetworkGenerate: [
                 'Download core snapshot from mainnet API': {


### PR DESCRIPTION
Alert is properly sent to #snapshot-notify:
<img width="523" alt="image" src="https://github.com/vegaprotocol/jenkins-shared-library/assets/1239637/0aaf3b3f-e11c-4f70-be7f-e84b57e4d625">

Here is a run I triggered: https://jenkins.vega.rocks/job/common/job/system-tests-snapshot-compatibility/112/