### PR TITLE
feat: improvement for the snapshot testing pipeline

### DIFF
--- a/vars/pipelineSnapshotTesting.groovy
+++ b/vars/pipelineSnapshotTesting.groovy
@@ -764,20 +764,22 @@ void sendSlackMessage(String vegaNetwork, String extraMsg, String catchupTime) {
 }
 
 boolean checkServerListening(String serverHost, int serverPort) {
-  timeoutMs = 1000
-  Socket s = null
-  try {
-    s = new Socket()
-    s.connect(new InetSocketAddress(serverHost, serverPort), timeoutMs);
-    return true
-  } catch (Exception e) {
-    return false
-  } finally {
-    if(s != null) {
-    try {s.close();}
-    catch(Exception e){}
-    }
-  }
+//   timeoutMs = 1000
+//   Socket s = null
+//   try {
+//     s = new Socket()
+//     s.connect(new InetSocketAddress(serverHost, serverPort), timeoutMs);
+//     return true
+//   } catch (Exception e) {
+//     return false
+//   } finally {
+//     if(s != null) {
+//     try {s.close();}
+//     catch(Exception e){}
+//     }
+//   }
+
+    return vegautils.shellCommand('nc -zvw2 ' + serverHost + ' ' + serverPort) == 0
 }
 
 def getSeedsAndRPCServers(String cometURL) {

--- a/vars/pipelineSnapshotTesting.groovy
+++ b/vars/pipelineSnapshotTesting.groovy
@@ -789,29 +789,39 @@ def getSeedsAndRPCServers(String cometURL) {
   for(peer in net_info.result.peers) {
     // Get domain/IP address and port
     def addr = peer.node_info.listen_addr.minus('tcp://').split(":")
+    print("Checking RPC peer: " + addr)
     if(addr.size()<2) {
+      print("   > RPC address rejected: size < 2")
       continue
     }
     def port = addr[1] as int
     addr = addr[0]
     if(["0.0.0.0", "127.0.0.1"].contains(addr)) {
+      print("   > RPC address rejected: localhost")
       continue
     }
     if(addr.startsWith("be")) {  // remove Block Explorers - as not stable
+      print("   > RPC address rejected: block explorer")
       continue
     }
     if( ! checkServerListening(addr, port)) {
+      print("   > RPC address rejected: not listening")
       continue
     }
     // Get RPC port
     def rpc_port = peer.node_info.other.rpc_address.minus('tcp://').split(":")
+    print("Checking RPC port: " + rpc_port)
     if(rpc_port.size()<2) {
+      print("   > RPC port rejected: size < 2")
       continue
     }
     rpc_port = rpc_port[1] as int
     if( ! checkServerListening(addr, rpc_port)) {
+      print("   > RPC port rejected: not listening")
       continue
     }
+
+    print("   > Done")
     // Get Peer ID
     def comet_peer_id = peer.node_info.id
     // Append result lists

--- a/vars/pipelineSnapshotTesting.groovy
+++ b/vars/pipelineSnapshotTesting.groovy
@@ -691,17 +691,18 @@ boolean isLocalDataNodeHealthy(boolean debug = false) {
         int datanode_height = headerMatcher[0][1] as int
         def stats = new groovy.json.JsonSlurperClassic().parseText(localServerStatsBody)
         int core_height = stats.statistics.blockHeight as int
-        if ((core_height - datanode_height).abs() > 30) {
+        if ((core_height - datanode_height).abs() > 10) {
             if (debug) {
-                println("Data Node healthcheck failed: data node (${datanode_height}) is more than 30 blocks behind core (${core_height}) for local data-node")
+                println("Data Node healthcheck failed: data node (${datanode_height}) is more than 10 blocks behind core (${core_height}) for local data-node")
             }
             return false
         }
         Date vega_time = Date.parse("yyyy-MM-dd'T'HH:mm:ss", stats.statistics.vegaTime.split("\\.")[0])
         Date current_time = Date.parse("yyyy-MM-dd'T'HH:mm:ss", stats.statistics.currentTime.split("\\.")[0])
-        if (TimeCategory.plus(vega_time, TimeCategory.getSeconds(10)) < current_time) {
+        // when there is a lot of happening on the network data-node can have some hiccup, especially on our poor hardware when its creating the network history snapshot.
+        if (TimeCategory.plus(vega_time, TimeCategory.getSeconds(30)) < current_time) {
             if (debug) {
-                println("Data Node healthcheck failed: core (${vega_time}) is more than 10 seconds behind now (${current_time}) for local data-node")
+                println("Data Node healthcheck failed: core (${vega_time}) is more than 30 seconds behind now (${current_time}) for local data-node")
             }
             return false
         }

--- a/vars/pipelineSnapshotTesting.groovy
+++ b/vars/pipelineSnapshotTesting.groovy
@@ -784,6 +784,7 @@ boolean checkServerListening(String serverHost, int serverPort) {
 // When validators or any peer of the network parameters
 // does not expose required endpoints, let's add our own servers
 // to provide minimal number of peers required to start the networks
+@NonCPS
 Tuple2<List, List> appendMinimumSeedsAndRPCServers(String networkName, List<String> seeds, List<String> rpcServers) {
     Map<String, List<String>> internalNodes = [
         "mainnet": ["api0.vega.community", "api1.vega.community", "api2.vega.community", "api3.vega.community"]

--- a/vars/pipelineSnapshotTesting.groovy
+++ b/vars/pipelineSnapshotTesting.groovy
@@ -400,7 +400,7 @@ void call(Map config=[:]) {
                             'Checks': {
                                 nicelyStopAfter(Integer.toString(params.TIMEOUT.toInteger() - 1)) {
                                     int startAt = currentBuild.duration
-                                    sleep(time: '120', unit:'SECONDS')
+                                    sleep(time: '60', unit:'SECONDS')
                                     // run at 20sec, 50sec, 1min20sec, 1min50sec, 2min20sec, ... since start
                                     int runEverySec = 10
                                     int runEveryMs = runEverySec * 1000
@@ -475,6 +475,12 @@ void call(Map config=[:]) {
                                                 if ( !isLocalDataNodeHealthy(true) ) {
                                                     notHealthyAgainCount += 1
                                                     println("!!!!!!!!!!!!!! Data Node is not healthy again !!!!!!!!!!!!!")
+                                                } else {
+                                                    // Remvoe previous penalties if data-node was able to recover and it is healthy now
+                                                    notHealthyAgainCount -= 1
+                                                    if (notHealthyAgainCount < 0) {
+                                                        notHealthyAgainCount = 0
+                                                    }
                                                 }
                                             }
                                         }
@@ -700,9 +706,9 @@ boolean isLocalDataNodeHealthy(boolean debug = false) {
         Date vega_time = Date.parse("yyyy-MM-dd'T'HH:mm:ss", stats.statistics.vegaTime.split("\\.")[0])
         Date current_time = Date.parse("yyyy-MM-dd'T'HH:mm:ss", stats.statistics.currentTime.split("\\.")[0])
         // when there is a lot of happening on the network data-node can have some hiccup, especially on our poor hardware when its creating the network history snapshot.
-        if (TimeCategory.plus(vega_time, TimeCategory.getSeconds(30)) < current_time) {
+        if (TimeCategory.plus(vega_time, TimeCategory.getSeconds(10)) < current_time) {
             if (debug) {
-                println("Data Node healthcheck failed: core (${vega_time}) is more than 30 seconds behind now (${current_time}) for local data-node")
+                println("Data Node healthcheck failed: core (${vega_time}) is more than 10 seconds behind now (${current_time}) for local data-node")
             }
             return false
         }

--- a/vars/pipelineSnapshotTesting.groovy
+++ b/vars/pipelineSnapshotTesting.groovy
@@ -691,9 +691,9 @@ boolean isLocalDataNodeHealthy(boolean debug = false) {
         int datanode_height = headerMatcher[0][1] as int
         def stats = new groovy.json.JsonSlurperClassic().parseText(localServerStatsBody)
         int core_height = stats.statistics.blockHeight as int
-        if ((core_height - datanode_height).abs() > 10) {
+        if ((core_height - datanode_height).abs() > 30) {
             if (debug) {
-                println("Data Node healthcheck failed: data node (${datanode_height}) is more than 10 blocks behind core (${core_height}) for local data-node")
+                println("Data Node healthcheck failed: data node (${datanode_height}) is more than 30 blocks behind core (${core_height}) for local data-node")
             }
             return false
         }

--- a/vars/pipelineSnapshotTesting.groovy
+++ b/vars/pipelineSnapshotTesting.groovy
@@ -400,7 +400,7 @@ void call(Map config=[:]) {
                             'Checks': {
                                 nicelyStopAfter(Integer.toString(params.TIMEOUT.toInteger() - 1)) {
                                     int startAt = currentBuild.duration
-                                    sleep(time: '60', unit:'SECONDS')
+                                    sleep(time: '120', unit:'SECONDS')
                                     // run at 20sec, 50sec, 1min20sec, 1min50sec, 2min20sec, ... since start
                                     int runEverySec = 10
                                     int runEveryMs = runEverySec * 1000

--- a/vars/pipelineSnapshotTesting.groovy
+++ b/vars/pipelineSnapshotTesting.groovy
@@ -476,6 +476,9 @@ void call(Map config=[:]) {
                                                     notHealthyAgainCount += 1
                                                     println("!!!!!!!!!!!!!! Data Node is not healthy again !!!!!!!!!!!!!")
                                                 } else {
+                                                    if (notHealthyAgainCount > 0) {
+                                                        println("!!!!!!!!!!!!!! Penalties for non-healthy node decreased by 1 !!!!!!!!!!!!!")
+                                                    }
                                                     // Remvoe previous penalties if data-node was able to recover and it is healthy now
                                                     notHealthyAgainCount -= 1
                                                     if (notHealthyAgainCount < 0) {

--- a/vars/pipelineSnapshotTesting.groovy
+++ b/vars/pipelineSnapshotTesting.groovy
@@ -764,25 +764,24 @@ void sendSlackMessage(String vegaNetwork, String extraMsg, String catchupTime) {
 }
 
 boolean checkServerListening(String serverHost, int serverPort) {
-//   timeoutMs = 1000
-//   Socket s = null
-//   try {
-//     s = new Socket()
-//     s.connect(new InetSocketAddress(serverHost, serverPort), timeoutMs);
-//     return true
-//   } catch (Exception e) {
-//     return false
-//   } finally {
-//     if(s != null) {
-//     try {s.close();}
-//     catch(Exception e){}
-//     }
-//   }
-
-    return vegautils.shellCommand('nc -zvw2 ' + serverHost + ' ' + serverPort) == 0
+  timeoutMs = 1000
+  Socket s = null
+  try {
+    s = new Socket()
+    s.connect(new InetSocketAddress(serverHost, serverPort), timeoutMs);
+    return true
+  } catch (Exception e) {
+    return false
+  } finally {
+    if(s != null) {
+    try {s.close();}
+    catch(Exception e){}
+    }
+  }
 }
 
 def getSeedsAndRPCServers(String cometURL) {
+  print('Commet URL: ' + cometURL + '/net_info')
   def net_info_req = new URL("${cometURL}/net_info").openConnection()
   def net_info = new groovy.json.JsonSlurperClassic().parseText(net_info_req.getInputStream().getText())
 

--- a/vars/pipelineSnapshotTesting.groovy
+++ b/vars/pipelineSnapshotTesting.groovy
@@ -802,7 +802,7 @@ List<String> appendMinimumRPCServers(String networkName, List<String> rpcServers
         }
     }
     
-    return new Tuple2(seeds.unique { a, b -> a <=> b }, rpcServers)
+    return rpcServers
 }
 
 def getSeedsAndRPCServers(String cometURL) {
@@ -834,13 +834,6 @@ def getSeedsAndRPCServers(String cometURL) {
       print("   > RPC address rejected: not listening")
       continue
     }
-    // Get RPC port
-    def rpc_port = peer.node_info.other.rpc_address.minus('tcp://').split(":")
-    print("Checking RPC port: " + rpc_port)
-    if(rpc_port.size()<2) {
-      print("   > RPC port rejected: size < 2")
-      continue
-    }
 
     // Get Peer ID
     def comet_peer_id = peer.node_info.id
@@ -848,7 +841,13 @@ def getSeedsAndRPCServers(String cometURL) {
     SEEDS.add("${comet_peer_id}@${addr}:${port}")
     print("   > SEED added ${comet_peer_id}@${addr}:${port}")
     
-
+    // Get RPC port
+    def rpc_port = peer.node_info.other.rpc_address.minus('tcp://').split(":")
+    print("Checking RPC port: " + rpc_port)
+    if(rpc_port.size()<2) {
+      print("   > RPC port rejected: size < 2")
+      continue
+    }
     rpc_port = rpc_port[1] as int
     if( ! checkServerListening(addr, rpc_port)) {
       print("   > RPC port rejected: not listening")

--- a/vars/vegautils.groovy
+++ b/vars/vegautils.groovy
@@ -42,6 +42,15 @@ String shellOutput(String command, boolean silent = false) {
     script: command).trim()
 }
 
+int shellCommand(String command, boolean silent = false) {
+  if (silent) {
+    command = '#!/bin/bash +x\n' + command
+  }
+
+  return sh(returnStatus: true,
+    script: command).trim() as int
+}
+
 Map<String, ?> networkStatistics(Map args=[:]) {
   String netName = args.get("netName", "")
   int nodesRetry = args.get("nodesRetry", 5)

--- a/vars/vegautils.groovy
+++ b/vars/vegautils.groovy
@@ -48,7 +48,7 @@ int shellCommand(String command, boolean silent = false) {
   }
 
   return sh(returnStatus: true,
-    script: command).trim() as int
+    script: command) as int
 }
 
 Map<String, ?> networkStatistics(Map args=[:]) {


### PR DESCRIPTION
# Changes

- Added some debugging info, it helps see the failure reason when some of the peers are not ready
- Improving mechanism for RPC_PEER address collection - important in mainnet because not everyone opens the 26657 port from the tendermint, so we have to use our own servers to sync.
- We increase the counter when data-node is not healthy. Sometimes there is just one hiccup usually when the data-node produces snapshots. When the data-node is healthy again I decrease those penalties counter. 