### PR TITLE
chore: point approbation at palazzo branch

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -1170,7 +1170,7 @@ def approbationParams(def config=[:]) {
 
         stringParam {
             name('SPECS_BRANCH')
-            defaultValue('cosmicelevator')
+            defaultValue('palazzo')
             description('Git branch, tag or hash of the vegaprotocol/specs repository')
             trim(true)
         }


### PR DESCRIPTION
In order to make the approbation pipeline point at the cosmicelevator branch in the specs repo this PR changes the branch its looking at.

This will allow us to track AC coverage on the palazzo branch during the development/testing of this .

There is a periodic (manual) task to keep the palazzo branch up-to-date with master which will mean that any changes for Palazzo specs/ACs will (with a slight lag) get updated and be present in the approbation run.