### PR TITLE
chore: Update jobs.groovy to have the correct default approbation version

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -1163,7 +1163,7 @@ def approbationParams(def config=[:]) {
 
         stringParam {
             name('APPROBATION_TAG')
-            defaultValue('v4.5.1')
+            defaultValue('v4.6.1')
             description('Approbation image tag. latest or specific version with v prefix')
             trim(true)
         }


### PR DESCRIPTION
This updates the version of approbation used as default by Jenkins