### PR TITLE
feat: increase mainnet backup timeout to 8h

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -2007,7 +2007,7 @@ def jobs = [
         disableConcurrentBuilds: false,
         parameterizedCron: [
             // automatic backup every 6h
-            'H */6 * * * %' + [
+            'H 2 * * * %' + [
                 'SERVER=api0.vega.community',
             ].join(';'),
         ].join('\n'),

--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -1982,7 +1982,7 @@ def jobs = [
             }
             stringParam {
                 name('TIMEOUT')
-                defaultValue('200')
+                defaultValue('480')
                 description('Global timeout in minutes')
                 trim(true)
             }

--- a/vars/pipelineBackupNodeZFS.groovy
+++ b/vars/pipelineBackupNodeZFS.groovy
@@ -142,10 +142,17 @@ def call() {
             }
         }
         post {
+            failure {
+                script {
+                    slack.sendSlackMessage channel: '#ops-alerts', name: 'Backup on ' + server + ' failed'
+                }
+            }
+            success {
+                script {
+                    slack.sendSlackMessage channel: '#ops-alerts', name: 'Backup on ' + server + ' finished successfully'
+                }
+            }
             always {
-                // script {
-                //     slack.slackSendCIStatus channel: '#tbd...', name: env.JOB_NAME, branch: 'Top-Up'
-                // }
                 cleanWs()
             }
         }

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -117,15 +117,15 @@ void sendSlackMessage(Map config) {
     String slackChannel = config.get('channel', '#env-deploy')
     String jobURL = config.get('jobURL', env.RUN_DISPLAY_URL)
     String duration = currentBuild.durationString - ' and counting'
-
-    msg = ":boom: ${msg}. <${jobURL}|Jenkins> :scream:"
+    String userMessage = config.get('msg', '')
+    msg = ":boom: ${userMessage}. <${jobURL}|Jenkins> :scream:"
     color = 'danger'
 
     if (currentResult == 'SUCCESS') {
-        msg = ":rocket: ${msg}. :astronaut:"
+        msg = ":rocket: ${userMessage}. :astronaut:"
         color = 'good'
     } else if (currentResult == 'ABORTED') {
-        msg = ":black_circle: ${msg}. See details in <${jobURL}|Jenkins> :gear:"
+        msg = ":black_circle: ${userMessage}. See details in <${jobURL}|Jenkins> :gear:"
         color = '#000000'
     }
 

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -112,3 +112,28 @@ void slackSendDeployStatus(Map config) {
         message: msg,
     )
 }
+
+void sendSlackMessage(Map config) {
+    String slackChannel = config.get('channel', '#env-deploy')
+    String jobURL = config.get('jobURL', env.RUN_DISPLAY_URL)
+    String duration = currentBuild.durationString - ' and counting'
+
+    msg = ":boom: ${msg}. <${jobURL}|Jenkins> :scream:"
+    color = 'danger'
+
+    if (currentResult == 'SUCCESS') {
+        msg = ":rocket: ${msg}. :astronaut:"
+        color = 'good'
+    } else if (currentResult == 'ABORTED') {
+        msg = ":black_circle: ${msg}. See details in <${jobURL}|Jenkins> :gear:"
+        color = '#000000'
+    }
+
+    msg += " (${duration})"
+
+    slackSend(
+        channel: slackChannel,
+        color: color,
+        message: msg,
+    )
+}

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -118,6 +118,7 @@ void sendSlackMessage(Map config) {
     String jobURL = config.get('jobURL', env.RUN_DISPLAY_URL)
     String duration = currentBuild.durationString - ' and counting'
     String userMessage = config.get('msg', '')
+    String currentResult = currentBuild.result ?: currentBuild.currentResult
     msg = ":boom: ${userMessage}. <${jobURL}|Jenkins> :scream:"
     color = 'danger'
 


### PR DESCRIPTION
close vegaprotocol/devops-infra#2095 .

# Changes

- Incrase mainnet backup timeline to 8h.
- Create mainnet backup every 24h instead of every 6h.
- Send messages to #ops-alerts for the backup pipeline