### PR TITLE
chore: updates version of approbation to the latest

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -1180,7 +1180,7 @@ def approbationParams(def config=[:]) {
 
         stringParam {
             name('APPROBATION_TAG')
-            defaultValue('v4.6.1')
+            defaultValue('v4.6.2')
             description('Approbation image tag. latest or specific version with v prefix')
             trim(true)
         }

--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -1180,7 +1180,7 @@ def approbationParams(def config=[:]) {
 
         stringParam {
             name('APPROBATION_TAG')
-            defaultValue('v4.6.2')
+            defaultValue('v4.7.0')
             description('Approbation image tag. latest or specific version with v prefix')
             trim(true)
         }


### PR DESCRIPTION
Updates the version of approbation on to 4.6.2 to get the updates from:

- https://github.com/vegaprotocol/approbation/pull/130