### PR TITLE
chore: check core unit tests for AC coverage

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -1276,7 +1276,7 @@ def approbationParams(def config=[:]) {
         if (config.type == 'core') {
             stringParam {
                 name('TESTS_ARG')
-                defaultValue('{/workspace/system-tests/tests/**/*.py,/workspace/vega/core/integration/**/*.{go,feature},/workspace/MultisigControl/test/*.js,/workspace/Vega_Token_V2/test/*.js,/workspace/Staking_Bridge/test/*.js}')
+                defaultValue('{/workspace/system-tests/tests/**/*.py,/workspace/vega/commands/**/*.{go,feature},/workspace/vega/core/integration/**/*.{go,feature},/workspace/MultisigControl/test/*.js,/workspace/Vega_Token_V2/test/*.js,/workspace/Staking_Bridge/test/*.js}')
                 description('--tests argument value')
                 trim(true)
             }


### PR DESCRIPTION
This PR updates the directories that approbation checks for AC codes.

Adds the path:

`/workspace/vega/commands/**/*.{go,feature}`
