### PR TITLE
feat: remove fuzz and split o-r

### DIFF
--- a/vars/pipelineCapsuleSystemTests.groovy
+++ b/vars/pipelineCapsuleSystemTests.groovy
@@ -42,8 +42,12 @@ void call() {
         pytestDirectory: 'tests/[h-nH-N]*',
         mark: 'full',
       ],
-      'full o-r': [
-        pytestDirectory: 'tests/[o-rO-R]*',
+      'full o-q': [
+        pytestDirectory: 'tests/[o-qO-Q]*',
+        mark: 'full',
+      ],
+      'full r': [
+        pytestDirectory: 'tests/[rR]*',
         mark: 'full',
       ],
       'full s': [
@@ -78,10 +82,6 @@ void call() {
         pytestDirectory: 'tests/validators/[r-zR-Z]*',
         mark: 'network_infra',
         capsuleConfig: 'capsule_config_network_infra.hcl'
-      ],
-      'fuzz': [
-        pytestDirectory: 'tests/fuzz*',
-        mark: 'fuzz',
       ],
     ]
   ][params.SCENARIO]


### PR DESCRIPTION
closes https://github.com/vegaprotocol/system-tests/issues/3468

Jenkins run down to 3hr11mins:
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests/detail/system-tests/10490/pipeline

Failures all look like our familiar friends, except for the soak-test which is failing on the event file diff check. I'll look into that but I think its worth merging this anyway so we can get the benefit of the overnight runs over the weekend.
