### PR TITLE
chore: disable overnight RL tests

### DIFF
--- a/dsl/scripts/jobs.groovy
+++ b/dsl/scripts/jobs.groovy
@@ -1375,12 +1375,6 @@ def vegaMarketSimParams(args=[:]) {
             trim(true)
         }
         stringParam {
-            name('NUM_RL_ITERATIONS')
-            defaultValue('200')
-            description('Number of iterations to run RL tests for')
-            trim(true)
-        }
-        stringParam {
             name('JENKINS_SHARED_LIB_BRANCH')
             defaultValue('main')
             description('Branch of jenkins-shared-library from which pipeline should be run')

--- a/vars/pipelineVegaMarketSim.groovy
+++ b/vars/pipelineVegaMarketSim.groovy
@@ -183,18 +183,6 @@ void call() {
                             }
                         }
                     }
-                    stage('RL Tests') {
-                        when {
-                            expression {
-                                params.RUN_LEARNING == true
-                            }
-                        }
-                        steps {
-                            sh label: 'Reinforcement Learning Test', script: '''
-                                poetry run scripts/run-learning-test.sh ${NUM_RL_ITERATIONS}
-                            '''
-                        }
-                    }
                     stage('Full Fuzzing Tests') {
                         environment {
                             PYTHONUNBUFFERED = "1"


### PR DESCRIPTION
Removes the reinforcement learning tests from the market-sim overnight runs.