### PR TITLE
chore: disable deprecated market-sim stages

### DIFF
--- a/vars/pipelineVegaMarketSim.groovy
+++ b/vars/pipelineVegaMarketSim.groovy
@@ -222,23 +222,6 @@ void call() {
                             }
                         }
                     }
-                    stage('Generate Plots') {
-                        when {
-                            expression {
-                                params.RUN_LEARNING == false
-                            }
-                        }
-                        steps {
-                            sh label: 'Market Behaviour Plots', script: '''
-                                poetry run scripts/run-plot-gen.sh
-                            '''
-                        }
-                        post {
-                            success {
-                                archiveArtifacts artifacts: 'run.jpg'
-                            }
-                        }
-                    }
                 }
                 // TODO: Print logs files from the /test-logs/*.test.log in case of failure
                 //       This is required because by default logs are not printed when the

--- a/vars/pipelineVegaMarketSim.groovy
+++ b/vars/pipelineVegaMarketSim.groovy
@@ -183,23 +183,6 @@ void call() {
                             }
                         }
                     }
-                    stage('Full Fuzzing Tests') {
-                        environment {
-                            PYTHONUNBUFFERED = "1"
-                        }
-                        when {
-                            expression {
-                                params.RUN_LEARNING == true
-                            }
-                        }
-                        steps {
-                            echo "Running full fuzzing tests"
-                            /* groovylint-disable-next-line GStringExpressionWithinString */
-                            sh label: 'Fuzz Test', script: '''
-                                poetry run scripts/run-fuzz-test.sh --steps ${NUM_FUZZ_STEPS}
-                            '''
-                        }
-                    }
                     stage('Sensible Fuzzing Tests') {
                         environment {
                             PYTHONUNBUFFERED = "1"


### PR DESCRIPTION
Overnight market sim runs currently failing as the legacy fuzz test puts a large load on data node and eventually times out making requests.

The updated "sensible" fuzz testing as been passing (and finding new panics) in overnight runs for enough time now to deprecate the legacy fuzzing and enable only the new fuzzing.

PR also does some housekeeping removing the old plot test stage as this has largely been replaced by vegapy.