### PR TITLE
feat: add vega version to slack message

### DIFF
--- a/vars/pipelineVegaMarketSim.groovy
+++ b/vars/pipelineVegaMarketSim.groovy
@@ -306,7 +306,7 @@ void sendSlackMessage() {
 
     String msgTitle = 'Vega Market Sim'
     if (params.RUN_LEARNING == true) {
-        msgTitle = 'Vega Market Sim - Nightly Long Tests'
+        msgTitle = "Vega Market Sim - Nightly Long Tests - ${params.VEGA_VERSION}"
     }
 
     if (currentResult == 'SUCCESS') {


### PR DESCRIPTION
... as per slack request, adds the vega version to the overnight run message posted to `#vega-market-sim-notify` each night.